### PR TITLE
Update CBMC symlinks and makefile paths.

### DIFF
--- a/cbmc/proofs/Makefile-project-defines
+++ b/cbmc/proofs/Makefile-project-defines
@@ -20,8 +20,9 @@ COMPILE_FLAGS += -std=gnu90
 # Preprocessor include paths -I...
 INCLUDES += -I$(SRCDIR)/cbmc/include
 INCLUDES += -I$(SRCDIR)/source/include
+INCLUDES += -I$(SRCDIR)/source/portable
 INCLUDES += -I$(SRCDIR)/source
-INCLUDES += -I$(SRCDIR)/third_party/http_parser
+INCLUDES += -I$(SRCDIR)/source/third_party/http_parser
 
 # Preprocessor definitions -D...
 DEFINES += -Dhttp_EXPORTS


### PR DESCRIPTION
How ensure CBMC proofs can run after restructuring and submoduling aws-templates-for-cbmc-proofs into cbmc/ folder:

1. Delete:
    - cmbc/include/README.md, 
    - cmbc/proofs/Makefile.common
    - cbmc/proofs/Makefile-project-targets
    - cbmc/proofs/Makefile-project-testing
    - cbmc/proofs/Makefile-template-defines
    - cbmc/proofs/prepare.py
    - cbmc/proofs/README.md
    - cbmc/sources/README.md
    - cbmc/stubs/README.md
    - cbmc/.gitignore
1. Run the following command to replace all symlinks and get the latest of non-symlinked files:
    ```
    cd cbmc
    python3 aws-templates-for-cbmc-proofs/scripts/setup.py
    What is the path to the source root:  ..
    ```
1. Open cbmc/proofs/Makefile-project-defines and update the include paths. We now have a portable folder.
1. Do a grep over the entire cbmc folder for "libraries/standard/<library_name>/" and replace with a empty string, "".
1. Do a grep over the entire cbmc folder for "libraries/standard/<library_name>/src" and replace with "source".
