### PR TITLE
Log test results after running the coverage target

### DIFF
--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -85,7 +85,8 @@ include( unit_test_build.cmake )
 
 # Add a target for running coverage on tests.
 add_custom_target( coverage
-    COMMAND ${CMAKE_COMMAND} -P ${MODULE_ROOT_DIR}/tools/cmock/coverage.cmake
+    COMMAND ${CMAKE_COMMAND} -DCMOCK_DIR=${CMOCK_DIR}
+    -P ${MODULE_ROOT_DIR}/tools/cmock/coverage.cmake
     DEPENDS cmock unity core_http_utest core_http_send_utest
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 )


### PR DESCRIPTION
CMake is updated to log test results after running the coverage target

