### PR TITLE
Modify CBMC proofs to make assumptions about malloc explicit.

### DIFF
--- a/test/cbmc/proofs/findHeaderFieldParserCallback/findHeaderFieldParserCallback_harness.c
+++ b/test/cbmc/proofs/findHeaderFieldParserCallback/findHeaderFieldParserCallback_harness.c
@@ -53,6 +53,7 @@ void findHeaderFieldParserCallback_harness()
 
     __CPROVER_assume( 0 < fieldContextLen && fieldContextLen < CBMC_MAX_OBJECT_SIZE );
     pFindHeaderContext->pField = ( char * ) malloc( fieldContextLen );
+    __CPROVER_assume( pFindHeaderContext->pField != NULL );
     pFindHeaderContext->fieldLen = fieldContextLen;
     pFindHeaderContext->fieldFound = 0;
     pFindHeaderContext->valueFound = 0;

--- a/test/cbmc/sources/http_cbmc_state.c
+++ b/test/cbmc/sources/http_cbmc_state.c
@@ -32,7 +32,7 @@
 void * mallocCanFail( size_t size )
 {
     __CPROVER_assert( size < CBMC_MAX_OBJECT_SIZE, "mallocCanFail size is too big" );
-    return nondet_bool() ? NULL : malloc( size );
+    return malloc( size );
 }
 
 HTTPRequestHeaders_t * allocateHttpRequestHeaders( HTTPRequestHeaders_t * pRequestHeaders )
@@ -188,6 +188,7 @@ http_parser * allocateHttpSendParser( http_parser * pHttpParser )
     if( pHttpParser == NULL )
     {
         pHttpParser = malloc( sizeof( http_parser ) );
+        __CPROVER_assume( pHttpParser != NULL );
     }
 
     pHttpParsingContext = allocateHttpSendParsingContext( NULL );
@@ -205,6 +206,7 @@ HTTPParsingContext_t * allocateHttpSendParsingContext( HTTPParsingContext_t * pH
     if( pHttpParsingContext == NULL )
     {
         pHttpParsingContext = malloc( sizeof( HTTPParsingContext_t ) );
+        __CPROVER_assume( pHttpParsingContext != NULL );
     }
 
     if( pHttpParsingContext != NULL )
@@ -240,6 +242,7 @@ http_parser * allocateHttpReadHeaderParser( http_parser * pHttpParser )
     if( pHttpParser == NULL )
     {
         pHttpParser = malloc( sizeof( http_parser ) );
+        __CPROVER_assume( pHttpParser != NULL );
     }
 
     pFindHeaderContext = allocateFindHeaderContext( NULL );
@@ -253,6 +256,7 @@ findHeaderContext_t * allocateFindHeaderContext( findHeaderContext_t * pFindHead
     if( pFindHeaderContext == NULL )
     {
         pFindHeaderContext = malloc( sizeof( findHeaderContext_t ) );
+        __CPROVER_assume( pFindHeaderContext != NULL );
     }
 
     return pFindHeaderContext;

--- a/test/cbmc/stubs/HTTPClient_Send_http_parser_execute.c
+++ b/test/cbmc/stubs/HTTPClient_Send_http_parser_execute.c
@@ -60,13 +60,15 @@ size_t http_parser_execute( http_parser * parser,
 
     pParsingContext = ( HTTPParsingContext_t * ) ( parser->data );
     /* Choose whether the parser found the header */
-    pParsingContext->pLastHeaderField = nondet_bool() ? NULL : malloc( fieldLength );
+    pParsingContext->pLastHeaderField = malloc( fieldLength );
+    __CPROVER_assume( pParsingContext->pLastHeaderField != NULL );
     pParsingContext->state = HTTP_PARSING_COMPLETE;
 
     if( pParsingContext->pLastHeaderField )
     {
         pParsingContext->lastHeaderFieldLen = fieldLength;
         pParsingContext->pLastHeaderValue = malloc( valueLength );
+        __CPROVER_assume( pParsingContext->pLastHeaderValue != NULL );
         pParsingContext->lastHeaderValueLen = valueLength;
     }
     else


### PR DESCRIPTION
Some proofs assume that some pointers returned by malloc are not
NULL. This patch modifies those proofs to make these assumptions
explicit with `__CPROVER_assume(pointer != NULL)` for all such
pointers.