### PR TITLE
Update HTTPRequestInfo_t.method to HTTPRequestInfo_t.pMethod for consistency

### DIFF
--- a/source/core_http_client.c
+++ b/source/core_http_client.c
@@ -1407,9 +1407,9 @@ HTTPStatus_t HTTPClient_InitializeRequestHeaders( HTTPRequestHeaders_t * pReques
         LogError( ( "Parameter check failed: pRequestInfo is NULL." ) );
         returnStatus = HTTP_INVALID_PARAMETER;
     }
-    else if( pRequestInfo->method == NULL )
+    else if( pRequestInfo->pMethod == NULL )
     {
-        LogError( ( "Parameter check failed: pRequestInfo->method is NULL." ) );
+        LogError( ( "Parameter check failed: pRequestInfo->pMethod is NULL." ) );
         returnStatus = HTTP_INVALID_PARAMETER;
     }
     else if( pRequestInfo->pHost == NULL )
@@ -1439,7 +1439,7 @@ HTTPStatus_t HTTPClient_InitializeRequestHeaders( HTTPRequestHeaders_t * pReques
 
         /* Write "<METHOD> <PATH> HTTP/1.1\r\n" to start the HTTP header. */
         returnStatus = writeRequestLine( pRequestHeaders,
-                                         pRequestInfo->method,
+                                         pRequestInfo->pMethod,
                                          pRequestInfo->methodLen,
                                          pRequestInfo->pPath,
                                          pRequestInfo->pathLen );

--- a/source/include/core_http_client.h
+++ b/source/include/core_http_client.h
@@ -353,7 +353,7 @@ typedef struct HTTPRequestInfo
     /**
      * @brief The HTTP request method e.g. "GET", "POST", "PUT", or "HEAD".
      */
-    const char * method;
+    const char * pMethod;
     size_t methodLen; /**< The length of the method in bytes. */
 
     /**
@@ -510,7 +510,7 @@ typedef struct HTTPResponse
  * of bytes written.
  *
  * Each line in the header is listed below and written in this order:
- *     <#HTTPRequestInfo_t.method> <#HTTPRequestInfo_t.pPath> <#HTTP_PROTOCOL_VERSION>
+ *     <#HTTPRequestInfo_t.pMethod> <#HTTPRequestInfo_t.pPath> <#HTTP_PROTOCOL_VERSION>
  *     User-Agent: <#HTTP_USER_AGENT_VALUE>
  *     Host: <#HTTPRequestInfo_t.pHost>
  *
@@ -539,7 +539,7 @@ typedef struct HTTPResponse
  * requestHeaders.bufferLen = 256;
  *
  * // Set the Method, Path, and Host in the HTTPRequestInfo_t.
- * requestInfo.method = HTTP_METHOD_GET;
+ * requestInfo.pMethod = HTTP_METHOD_GET;
  * requestInfo.methodLen = sizeof( HTTP_METHOD_GET ) - 1U;
  * requestInfo.pPath = "/html/rfc2616"
  * requestInfo.pathLen = sizeof( "/html/rfc2616" ) - 1U;

--- a/test/cbmc/sources/http_cbmc_state.c
+++ b/test/cbmc/sources/http_cbmc_state.c
@@ -74,7 +74,7 @@ HTTPRequestInfo_t * allocateHttpRequestInfo( HTTPRequestInfo_t * pRequestInfo )
     if( pRequestInfo != NULL )
     {
         __CPROVER_assume( pRequestInfo->methodLen < CBMC_MAX_OBJECT_SIZE );
-        pRequestInfo->method = mallocCanFail( pRequestInfo->methodLen );
+        pRequestInfo->pMethod = mallocCanFail( pRequestInfo->methodLen );
 
         __CPROVER_assume( pRequestInfo->hostLen < CBMC_MAX_OBJECT_SIZE );
         pRequestInfo->pHost = mallocCanFail( pRequestInfo->hostLen );

--- a/test/unit-test/core_http_utest.c
+++ b/test/unit-test/core_http_utest.c
@@ -395,7 +395,7 @@ int suiteTearDown( int numFailures )
  */
 static void setupRequestInfo( HTTPRequestInfo_t * pRequestInfo )
 {
-    pRequestInfo->method = HTTP_METHOD_GET;
+    pRequestInfo->pMethod = HTTP_METHOD_GET;
     pRequestInfo->methodLen = HTTP_METHOD_GET_LEN;
     pRequestInfo->pPath = HTTP_TEST_REQUEST_PATH;
     pRequestInfo->pathLen = HTTP_TEST_REQUEST_PATH_LEN;
@@ -470,10 +470,10 @@ void test_Http_InitializeRequestHeaders_Invalid_Params()
     httpStatus = HTTPClient_InitializeRequestHeaders( &requestHeaders, NULL );
     TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, httpStatus );
 
-    /* Test requestInfo.method == NULL. */
+    /* Test requestInfo.pMethod == NULL. */
     httpStatus = HTTPClient_InitializeRequestHeaders( &requestHeaders, &requestInfo );
     TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, httpStatus );
-    requestInfo.method = HTTP_METHOD_GET;
+    requestInfo.pMethod = HTTP_METHOD_GET;
 
     /* Test requestInfo.pHost == NULL. */
     httpStatus = HTTPClient_InitializeRequestHeaders( &requestHeaders, &requestInfo );


### PR DESCRIPTION
- The title says it all.
- This parameters was missed somehow... and no one said anything... and we kept using it EVERYWHERE! AGH!

**Next steps:**  
Update submodule in CSDK and update usage everywhere there in all integ tests and demos.