### PR TITLE
Change enum values from all uppercase to camel case for consistency

### DIFF
--- a/lexicon.txt
+++ b/lexicon.txt
@@ -85,6 +85,7 @@ httpresponse
 https
 httpsecurityalertresponseheaderssizelimitexceeded
 httpsecurityalertextraneousresponsedata
+httpsecurityalertinvalidchunkheader
 httpstatus
 httpsuccess
 ietf

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -83,9 +83,10 @@ httprequestheaders
 httprequestinfo
 httpresponse
 https
-httpsecurityalertresponseheaderssizelimitexceeded
 httpsecurityalertextraneousresponsedata
 httpsecurityalertinvalidchunkheader
+httpsecurityalertinvalidprotocolversion
+httpsecurityalertresponseheaderssizelimitexceeded
 httpstatus
 httpsuccess
 ietf

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -83,6 +83,7 @@ httprequestheaders
 httprequestinfo
 httpresponse
 https
+httpsecurityalertresponseheaderssizelimitexceeded
 httpstatus
 httpsuccess
 ietf

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -76,6 +76,7 @@ httpparserxxxxcallback
 httpparserxxxxcallbacks
 httpparsingcontext
 httpparsingstate
+httppartialresponse
 httprequestheaders
 httprequestinfo
 httpresponse

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -60,6 +60,7 @@ hpe
 html
 http
 httpclient
+httpheadernotfound
 httpinsufficientmemory
 httpinvalidparameter
 httplibrarystatus

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -63,6 +63,7 @@ httpclient
 httpheadernotfound
 httpinsufficientmemory
 httpinvalidparameter
+httpinvalidresponse
 httplibrarystatus
 httpnetworkerror
 httpnoresponse

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -86,6 +86,7 @@ https
 httpsecurityalertextraneousresponsedata
 httpsecurityalertinvalidchunkheader
 httpsecurityalertinvalidprotocolversion
+httpsecurityalertinvalidstatuscode
 httpsecurityalertresponseheaderssizelimitexceeded
 httpstatus
 httpsuccess

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -63,6 +63,7 @@ httpclient
 httpinvalidparameter
 httplibrarystatus
 httpnetworkerror
+httpnoresponse
 httpparseonstatusfieldcallback
 httpparser
 httpparseronbodycallback

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -60,6 +60,7 @@ hpe
 html
 http
 httpclient
+httpinsufficientmemory
 httpinvalidparameter
 httplibrarystatus
 httpnetworkerror

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -84,6 +84,7 @@ httprequestinfo
 httpresponse
 https
 httpsecurityalertextraneousresponsedata
+httpsecurityalertinvalidcharacter
 httpsecurityalertinvalidchunkheader
 httpsecurityalertinvalidprotocolversion
 httpsecurityalertinvalidstatuscode

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -67,6 +67,7 @@ httpnetworkerror
 httpnoresponse
 httpparseonstatusfieldcallback
 httpparser
+httpparserinternalerror
 httpparseronbodycallback
 httpparseronheaderfieldcallback
 httpparseronheaderscompletecallback

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -60,6 +60,7 @@ hpe
 html
 http
 httpclient
+httpinvalidparameter
 httplibrarystatus
 httpparseonstatusfieldcallback
 httpparser

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -79,6 +79,7 @@ httprequestinfo
 httpresponse
 https
 httpstatus
+httpsuccess
 ietf
 ifndef
 inc

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -84,6 +84,7 @@ httprequestinfo
 httpresponse
 https
 httpsecurityalertresponseheaderssizelimitexceeded
+httpsecurityalertextraneousresponsedata
 httpstatus
 httpsuccess
 ietf

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -84,6 +84,7 @@ httprequestinfo
 httpresponse
 https
 httpsecurityalertextraneousresponsedata
+httpsecurityalertinvalidcontentlength
 httpsecurityalertinvalidcharacter
 httpsecurityalertinvalidchunkheader
 httpsecurityalertinvalidprotocolversion

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -62,6 +62,7 @@ http
 httpclient
 httpinvalidparameter
 httplibrarystatus
+httpnetworkerror
 httpparseonstatusfieldcallback
 httpparser
 httpparseronbodycallback

--- a/source/core_http_client.c
+++ b/source/core_http_client.c
@@ -162,7 +162,7 @@ static HTTPStatus_t receiveHttpData( const TransportInterface_t * pTransport,
  * @return Returns #HTTPSuccess if the parsing state is complete. If
  * the parsing state denotes it never started, then return #HTTP_NO_RESPONSE. If
  * the parsing state is incomplete, then if the response buffer is not full
- * #HTTP_PARTIAL_RESPONSE is returned. If the parsing state is incomplete, then
+ * #HTTPPartialResponse is returned. If the parsing state is incomplete, then
  * if the response buffer is full #HTTP_INSUFFICIENT_MEMORY is returned.
  */
 static HTTPStatus_t getFinalResponseStatus( HTTPParsingState_t parsingState,
@@ -1847,7 +1847,7 @@ static HTTPStatus_t getFinalResponseStatus( HTTPParsingState_t parsingState,
                         "receive(): ResponseSize=%lu, TotalBufferSize=%lu",
                         ( unsigned long ) totalReceived,
                         ( unsigned long ) ( responseBufferLen - totalReceived ) ) );
-            returnStatus = HTTP_PARTIAL_RESPONSE;
+            returnStatus = HTTPPartialResponse;
         }
     }
     else
@@ -2370,8 +2370,8 @@ const char * HTTPClient_strerror( HTTPStatus_t status )
             str = "HTTPNetworkError";
             break;
 
-        case HTTP_PARTIAL_RESPONSE:
-            str = "HTTP_PARTIAL_RESPONSE";
+        case HTTPPartialResponse:
+            str = "HTTPPartialResponse";
             break;
 
         case HTTP_NO_RESPONSE:

--- a/source/core_http_client.c
+++ b/source/core_http_client.c
@@ -75,7 +75,7 @@ static HTTPStatus_t sendHttpHeaders( const TransportInterface_t * pTransport,
  * @param[in] contentLength The Content-Length header value to write.
  *
  * @return #HTTPSuccess if successful. If there was insufficient memory in the
- * application buffer, then #HTTP_INSUFFICIENT_MEMORY is returned.
+ * application buffer, then #HTTPInsufficientMemory is returned.
  */
 static HTTPStatus_t addContentLengthHeader( HTTPRequestHeaders_t * pRequestHeaders,
                                             size_t contentLength );
@@ -107,7 +107,7 @@ static HTTPStatus_t sendHttpBody( const TransportInterface_t * pTransport,
  * @param[in] valueLen The byte length of the header field value.
  *
  * @return #HTTPSuccess if successful. If there was insufficient memory in the
- * application buffer, then #HTTP_INSUFFICIENT_MEMORY is returned.
+ * application buffer, then #HTTPInsufficientMemory is returned.
  */
 static HTTPStatus_t addHeader( HTTPRequestHeaders_t * pRequestHeaders,
                                const char * pField,
@@ -127,7 +127,7 @@ static HTTPStatus_t addHeader( HTTPRequestHeaders_t * pRequestHeaders,
  * should be passed.
  *
  * @return #HTTPSuccess if successful. If there was insufficient memory in the
- * application buffer, then #HTTP_INSUFFICIENT_MEMORY is returned.
+ * application buffer, then #HTTPInsufficientMemory is returned.
  */
 static HTTPStatus_t addRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
                                     int32_t rangeStartOrlastNbytes,
@@ -163,7 +163,7 @@ static HTTPStatus_t receiveHttpData( const TransportInterface_t * pTransport,
  * the parsing state denotes it never started, then return #HTTPNoResponse. If
  * the parsing state is incomplete, then if the response buffer is not full
  * #HTTPPartialResponse is returned. If the parsing state is incomplete, then
- * if the response buffer is full #HTTP_INSUFFICIENT_MEMORY is returned.
+ * if the response buffer is full #HTTPInsufficientMemory is returned.
  */
 static HTTPStatus_t getFinalResponseStatus( HTTPParsingState_t parsingState,
                                             size_t totalReceived,
@@ -209,7 +209,7 @@ static uint8_t convertInt32ToAscii( int32_t value,
  * @param pathLen The byte length of the request path.
  *
  * @return #HTTPSuccess if successful. If there was insufficient memory in the
- * application buffer, then #HTTP_INSUFFICIENT_MEMORY is returned.
+ * application buffer, then #HTTPInsufficientMemory is returned.
  */
 static HTTPStatus_t writeRequestLine( HTTPRequestHeaders_t * pRequestHeaders,
                                       const char * pMethod,
@@ -1245,7 +1245,7 @@ static HTTPStatus_t addHeader( HTTPRequestHeaders_t * pRequestHeaders,
                     "RequiredBytes=%lu, RemainingBufferSize=%lu",
                     ( unsigned long ) toAddLen,
                     ( unsigned long ) ( pRequestHeaders->bufferLen - pRequestHeaders->headersLen ) ) );
-        returnStatus = HTTP_INSUFFICIENT_MEMORY;
+        returnStatus = HTTPInsufficientMemory;
     }
 
     return returnStatus;
@@ -1341,7 +1341,7 @@ static HTTPStatus_t writeRequestLine( HTTPRequestHeaders_t * pRequestHeaders,
 
     if( ( toAddLen + pRequestHeaders->headersLen ) > pRequestHeaders->bufferLen )
     {
-        returnStatus = HTTP_INSUFFICIENT_MEMORY;
+        returnStatus = HTTPInsufficientMemory;
     }
 
     if( returnStatus == HTTPSuccess )
@@ -1839,7 +1839,7 @@ static HTTPStatus_t getFinalResponseStatus( HTTPParsingState_t parsingState,
                         " interface: Response buffer has insufficient "
                         "space: responseBufferLen=%lu",
                         ( unsigned long ) responseBufferLen ) );
-            returnStatus = HTTP_INSUFFICIENT_MEMORY;
+            returnStatus = HTTPInsufficientMemory;
         }
         else
         {
@@ -2378,8 +2378,8 @@ const char * HTTPClient_strerror( HTTPStatus_t status )
             str = "HTTPNoResponse";
             break;
 
-        case HTTP_INSUFFICIENT_MEMORY:
-            str = "HTTP_INSUFFICIENT_MEMORY";
+        case HTTPInsufficientMemory:
+            str = "HTTPInsufficientMemory";
             break;
 
         case HTTP_SECURITY_ALERT_RESPONSE_HEADERS_SIZE_LIMIT_EXCEEDED:

--- a/source/core_http_client.c
+++ b/source/core_http_client.c
@@ -500,7 +500,7 @@ static void processCompleteHeader( HTTPParsingContext_t * pParsingContext );
  * - #HTTPSecurityAlertResponseHeadersSizeLimitExceeded
  * - #HTTPSecurityAlertExtraneousResponseData
  * - #HTTPSecurityAlertInvalidChunkHeader
- * - #HTTP_SECURITY_ALERT_INVALID_PROTOCOL_VERSION
+ * - #HTTPSecurityAlertInvalidProtocolVersion
  * - #HTTP_SECURITY_ALERT_INVALID_STATUS_CODE
  * - #HTTP_SECURITY_ALERT_INVALID_CHARACTER
  * - #HTTP_SECURITY_ALERT_INVALID_CONTENT_LENGTH
@@ -975,7 +975,7 @@ static HTTPStatus_t processHttpParserError( const http_parser * pHttpParser )
              * character and location. */
             LogError( ( "Response parsing error: Invalid character found in "
                         "HTTP protocol version." ) );
-            returnStatus = HTTP_SECURITY_ALERT_INVALID_PROTOCOL_VERSION;
+            returnStatus = HTTPSecurityAlertInvalidProtocolVersion;
             break;
 
         case HPE_INVALID_STATUS:
@@ -2394,8 +2394,8 @@ const char * HTTPClient_strerror( HTTPStatus_t status )
             str = "HTTPSecurityAlertInvalidChunkHeader";
             break;
 
-        case HTTP_SECURITY_ALERT_INVALID_PROTOCOL_VERSION:
-            str = "HTTP_SECURITY_ALERT_INVALID_PROTOCOL_VERSION";
+        case HTTPSecurityAlertInvalidProtocolVersion:
+            str = "HTTPSecurityAlertInvalidProtocolVersion";
             break;
 
         case HTTP_SECURITY_ALERT_INVALID_STATUS_CODE:

--- a/source/core_http_client.c
+++ b/source/core_http_client.c
@@ -499,7 +499,7 @@ static void processCompleteHeader( HTTPParsingContext_t * pParsingContext );
  * - #HTTPSuccess
  * - #HTTPSecurityAlertResponseHeadersSizeLimitExceeded
  * - #HTTPSecurityAlertExtraneousResponseData
- * - #HTTP_SECURITY_ALERT_INVALID_CHUNK_HEADER
+ * - #HTTPSecurityAlertInvalidChunkHeader
  * - #HTTP_SECURITY_ALERT_INVALID_PROTOCOL_VERSION
  * - #HTTP_SECURITY_ALERT_INVALID_STATUS_CODE
  * - #HTTP_SECURITY_ALERT_INVALID_CHARACTER
@@ -966,7 +966,7 @@ static HTTPStatus_t processHttpParserError( const http_parser * pHttpParser )
              * character and location. */
             LogError( ( "Response parsing error: Invalid character found in "
                         "chunk header." ) );
-            returnStatus = HTTP_SECURITY_ALERT_INVALID_CHUNK_HEADER;
+            returnStatus = HTTPSecurityAlertInvalidChunkHeader;
             break;
 
         case HPE_INVALID_VERSION:
@@ -2390,8 +2390,8 @@ const char * HTTPClient_strerror( HTTPStatus_t status )
             str = "HTTPSecurityAlertExtraneousResponseData";
             break;
 
-        case HTTP_SECURITY_ALERT_INVALID_CHUNK_HEADER:
-            str = "HTTP_SECURITY_ALERT_INVALID_CHUNK_HEADER";
+        case HTTPSecurityAlertInvalidChunkHeader:
+            str = "HTTPSecurityAlertInvalidChunkHeader";
             break;
 
         case HTTP_SECURITY_ALERT_INVALID_PROTOCOL_VERSION:

--- a/source/core_http_client.c
+++ b/source/core_http_client.c
@@ -40,7 +40,7 @@
  * @param[in] pData HTTP request data to send.
  * @param[in] dataLen HTTP request data length.
  *
- * @return #HTTP_SUCCESS if successful. If there was a network error or less
+ * @return #HTTPSuccess if successful. If there was a network error or less
  * bytes than what were specified were sent, then #HTTP_NETWORK_ERROR is
  * returned.
  */
@@ -58,7 +58,7 @@ static HTTPStatus_t sendHttpData( const TransportInterface_t * pTransport,
  * used to generated a Content-Length header.
  * @param[in] sendFlags Application provided flags to #HTTPClient_Send.
  *
- * @return #HTTP_SUCCESS if successful. If there was a network error or less
+ * @return #HTTPSuccess if successful. If there was a network error or less
  * bytes than what were specified were sent, then #HTTP_NETWORK_ERROR is
  * returned.
  */
@@ -74,7 +74,7 @@ static HTTPStatus_t sendHttpHeaders( const TransportInterface_t * pTransport,
  * @param[in] pRequestHeaders Request header buffer information.
  * @param[in] contentLength The Content-Length header value to write.
  *
- * @return #HTTP_SUCCESS if successful. If there was insufficient memory in the
+ * @return #HTTPSuccess if successful. If there was insufficient memory in the
  * application buffer, then #HTTP_INSUFFICIENT_MEMORY is returned.
  */
 static HTTPStatus_t addContentLengthHeader( HTTPRequestHeaders_t * pRequestHeaders,
@@ -87,7 +87,7 @@ static HTTPStatus_t addContentLengthHeader( HTTPRequestHeaders_t * pRequestHeade
  * @param[in] pRequestBodyBuf Request body buffer.
  * @param[in] reqBodyBufLen Length of the request body buffer.
  *
- * @return #HTTP_SUCCESS if successful. If there was a network error or less
+ * @return #HTTPSuccess if successful. If there was a network error or less
  * bytes than what was specified were sent, then #HTTP_NETWORK_ERROR is
  * returned.
  */
@@ -106,7 +106,7 @@ static HTTPStatus_t sendHttpBody( const TransportInterface_t * pTransport,
  * @param[in] pValue The ISO 8859-1 encoded header value to write.
  * @param[in] valueLen The byte length of the header field value.
  *
- * @return #HTTP_SUCCESS if successful. If there was insufficient memory in the
+ * @return #HTTPSuccess if successful. If there was insufficient memory in the
  * application buffer, then #HTTP_INSUFFICIENT_MEMORY is returned.
  */
 static HTTPStatus_t addHeader( HTTPRequestHeaders_t * pRequestHeaders,
@@ -126,7 +126,7 @@ static HTTPStatus_t addHeader( HTTPRequestHeaders_t * pRequestHeaders,
  * byte in Range Specifications 2. and 3., #HTTP_RANGE_REQUEST_END_OF_FILE
  * should be passed.
  *
- * @return #HTTP_SUCCESS if successful. If there was insufficient memory in the
+ * @return #HTTPSuccess if successful. If there was insufficient memory in the
  * application buffer, then #HTTP_INSUFFICIENT_MEMORY is returned.
  */
 static HTTPStatus_t addRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
@@ -141,7 +141,7 @@ static HTTPStatus_t addRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
  * @param[in] bufferLen Length of the response buffer.
  * @param[out] pBytesReceived Bytes received from the transport interface.
  *
- * @return Returns #HTTP_SUCCESS if successful. If there was a network error or
+ * @return Returns #HTTPSuccess if successful. If there was a network error or
  * more bytes than what was specified were read, then #HTTP_NETWORK_ERROR is
  * returned.
  */
@@ -159,7 +159,7 @@ static HTTPStatus_t receiveHttpData( const TransportInterface_t * pTransport,
  * buffer.
  * @param[in] responseBufferLen The length of the response buffer.
  *
- * @return Returns #HTTP_SUCCESS if the parsing state is complete. If
+ * @return Returns #HTTPSuccess if the parsing state is complete. If
  * the parsing state denotes it never started, then return #HTTP_NO_RESPONSE. If
  * the parsing state is incomplete, then if the response buffer is not full
  * #HTTP_PARTIAL_RESPONSE is returned. If the parsing state is incomplete, then
@@ -176,7 +176,7 @@ static HTTPStatus_t getFinalResponseStatus( HTTPParsingState_t parsingState,
  * @param[in] pResponse Response message to receive data from the network.
  * @param[in] pRequestHeaders Request headers for the corresponding HTTP request.
  *
- * @return Returns #HTTP_SUCCESS if successful. Please see #receiveHttpData,
+ * @return Returns #HTTPSuccess if successful. Please see #receiveHttpData,
  * #parseHttpResponse, and #getFinalResponseStatus for other statuses returned.
  */
 static HTTPStatus_t receiveAndParseHttpResponse( const TransportInterface_t * pTransport,
@@ -208,7 +208,7 @@ static uint8_t convertInt32ToAscii( int32_t value,
  * @param pPath The Request-URI to the objects of interest, e.g. "/path/to/item.txt".
  * @param pathLen The byte length of the request path.
  *
- * @return #HTTP_SUCCESS if successful. If there was insufficient memory in the
+ * @return #HTTPSuccess if successful. If there was insufficient memory in the
  * application buffer, then #HTTP_INSUFFICIENT_MEMORY is returned.
  */
 static HTTPStatus_t writeRequestLine( HTTPRequestHeaders_t * pRequestHeaders,
@@ -228,7 +228,7 @@ static HTTPStatus_t writeRequestLine( HTTPRequestHeaders_t * pRequestHeaders,
  * @param[out] pValueLen The length of pValue.
  *
  * @return One of the following:
- * - #HTTP_SUCCESS when header is found in the response.
+ * - #HTTPSuccess when header is found in the response.
  * - #HTTP_HEADER_NOT_FOUND if requested header is not found in response.
  * - #HTTP_INVALID_RESPONSE if passed response is invalid for parsing.
  * - #HTTP_PARSER_INTERNAL_ERROR for any parsing errors.
@@ -314,7 +314,7 @@ static void initializeParsingContextForFirstResponse( HTTPParsingContext_t * pPa
  * to 1, otherwise this is set to 0.
  *
  * @return One of the following:
- * - #HTTP_SUCCESS
+ * - #HTTPSuccess
  * - #HTTP_INVALID_PARAMETER
  * - Please see #processHttpParserError for parsing errors returned.
  */
@@ -496,7 +496,7 @@ static void processCompleteHeader( HTTPParsingContext_t * pParsingContext );
  * @param[in] pHttpParser Third-party HTTP parsing context.
  *
  * @return One of the following:
- * - #HTTP_SUCCESS
+ * - #HTTPSuccess
  * - #HTTP_SECURITY_ALERT_RESPONSE_HEADERS_SIZE_LIMIT_EXCEEDED
  * - #HTTP_SECURITY_ALERT_EXTRANEOUS_RESPONSE_DATA
  * - #HTTP_SECURITY_ALERT_INVALID_CHUNK_HEADER
@@ -930,7 +930,7 @@ static void initializeParsingContextForFirstResponse( HTTPParsingContext_t * pPa
 
 static HTTPStatus_t processHttpParserError( const http_parser * pHttpParser )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
 
     assert( pHttpParser != NULL );
 
@@ -1182,7 +1182,7 @@ static HTTPStatus_t addHeader( HTTPRequestHeaders_t * pRequestHeaders,
                                const char * pValue,
                                size_t valueLen )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
     char * pBufferCur = ( char * ) ( pRequestHeaders->pBuffer + pRequestHeaders->headersLen );
     size_t toAddLen = 0u;
     size_t backtrackHeaderLen = pRequestHeaders->headersLen;
@@ -1257,7 +1257,7 @@ static HTTPStatus_t addRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
                                     int32_t rangeStartOrlastNbytes,
                                     int32_t rangeEnd )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
     char rangeValueBuffer[ HTTP_MAX_RANGE_REQUEST_VALUE_LEN ];
     size_t rangeValueLength = 0u;
 
@@ -1324,7 +1324,7 @@ static HTTPStatus_t writeRequestLine( HTTPRequestHeaders_t * pRequestHeaders,
                                       const char * pPath,
                                       size_t pathLen )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
     char * pBufferCur = ( char * ) ( pRequestHeaders->pBuffer );
     size_t toAddLen = methodLen +                 \
                       SPACE_CHARACTER_LEN +       \
@@ -1344,7 +1344,7 @@ static HTTPStatus_t writeRequestLine( HTTPRequestHeaders_t * pRequestHeaders,
         returnStatus = HTTP_INSUFFICIENT_MEMORY;
     }
 
-    if( returnStatus == HTTP_SUCCESS )
+    if( returnStatus == HTTPSuccess )
     {
         /* Write "<METHOD> <PATH> HTTP/1.1\r\n" to start the HTTP header. */
         ( void ) memcpy( pBufferCur, pMethod, methodLen );
@@ -1389,7 +1389,7 @@ static HTTPStatus_t writeRequestLine( HTTPRequestHeaders_t * pRequestHeaders,
 HTTPStatus_t HTTPClient_InitializeRequestHeaders( HTTPRequestHeaders_t * pRequestHeaders,
                                                   const HTTPRequestInfo_t * pRequestInfo )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
 
     /* Check for NULL parameters. */
     if( pRequestHeaders == NULL )
@@ -1432,7 +1432,7 @@ HTTPStatus_t HTTPClient_InitializeRequestHeaders( HTTPRequestHeaders_t * pReques
         /* Empty else MISRA 15.7 */
     }
 
-    if( returnStatus == HTTP_SUCCESS )
+    if( returnStatus == HTTPSuccess )
     {
         /* Reset application-provided parameters. */
         pRequestHeaders->headersLen = 0u;
@@ -1445,7 +1445,7 @@ HTTPStatus_t HTTPClient_InitializeRequestHeaders( HTTPRequestHeaders_t * pReques
                                          pRequestInfo->pathLen );
     }
 
-    if( returnStatus == HTTP_SUCCESS )
+    if( returnStatus == HTTPSuccess )
     {
         /* Write "User-Agent: <Value>". */
         returnStatus = addHeader( pRequestHeaders,
@@ -1455,7 +1455,7 @@ HTTPStatus_t HTTPClient_InitializeRequestHeaders( HTTPRequestHeaders_t * pReques
                                   HTTP_USER_AGENT_VALUE_LEN );
     }
 
-    if( returnStatus == HTTP_SUCCESS )
+    if( returnStatus == HTTPSuccess )
     {
         /* Write "Host: <Value>". */
         returnStatus = addHeader( pRequestHeaders,
@@ -1465,7 +1465,7 @@ HTTPStatus_t HTTPClient_InitializeRequestHeaders( HTTPRequestHeaders_t * pReques
                                   pRequestInfo->hostLen );
     }
 
-    if( returnStatus == HTTP_SUCCESS )
+    if( returnStatus == HTTPSuccess )
     {
         if( ( HTTP_REQUEST_KEEP_ALIVE_FLAG & pRequestInfo->reqFlags ) != 0u )
         {
@@ -1489,7 +1489,7 @@ HTTPStatus_t HTTPClient_AddHeader( HTTPRequestHeaders_t * pRequestHeaders,
                                    const char * pValue,
                                    size_t valueLen )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
 
     /* Check for NULL parameters. */
     if( pRequestHeaders == NULL )
@@ -1532,7 +1532,7 @@ HTTPStatus_t HTTPClient_AddHeader( HTTPRequestHeaders_t * pRequestHeaders,
         /* Empty else MISRA 15.7 */
     }
 
-    if( returnStatus == HTTP_SUCCESS )
+    if( returnStatus == HTTPSuccess )
     {
         returnStatus = addHeader( pRequestHeaders,
                                   pField, fieldLen, pValue, valueLen );
@@ -1547,7 +1547,7 @@ HTTPStatus_t HTTPClient_AddRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
                                         int32_t rangeStartOrlastNbytes,
                                         int32_t rangeEnd )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
 
     if( pRequestHeaders == NULL )
     {
@@ -1612,7 +1612,7 @@ static HTTPStatus_t sendHttpData( const TransportInterface_t * pTransport,
                                   const uint8_t * pData,
                                   size_t dataLen )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
     const uint8_t * pIndex = pData;
     int32_t transportStatus = 0;
     size_t bytesRemaining = dataLen;
@@ -1654,7 +1654,7 @@ static HTTPStatus_t sendHttpData( const TransportInterface_t * pTransport,
         }
     }
 
-    if( returnStatus == HTTP_SUCCESS )
+    if( returnStatus == HTTPSuccess )
     {
         LogDebug( ( "Sent HTTP data over the transport: BytesSent=%d",
                     transportStatus ) );
@@ -1668,7 +1668,7 @@ static HTTPStatus_t sendHttpData( const TransportInterface_t * pTransport,
 static HTTPStatus_t addContentLengthHeader( HTTPRequestHeaders_t * pRequestHeaders,
                                             size_t contentLength )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
     char pContentLengthValue[ MAX_INT32_NO_OF_DECIMAL_DIGITS ] = { '\0' };
     uint8_t contentLengthValueNumBytes = 0u;
 
@@ -1685,7 +1685,7 @@ static HTTPStatus_t addContentLengthHeader( HTTPRequestHeaders_t * pRequestHeade
                               pContentLengthValue,
                               contentLengthValueNumBytes );
 
-    if( returnStatus != HTTP_SUCCESS )
+    if( returnStatus != HTTPSuccess )
     {
         LogError( ( "Failed to write Content-Length header to the request "
                     "header buffer: ContentLengthValue: %lu",
@@ -1702,7 +1702,7 @@ static HTTPStatus_t sendHttpHeaders( const TransportInterface_t * pTransport,
                                      size_t reqBodyLen,
                                      uint32_t sendFlags )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
     uint8_t shouldSendContentLength = 0u;
 
     assert( pTransport != NULL );
@@ -1719,7 +1719,7 @@ static HTTPStatus_t sendHttpHeaders( const TransportInterface_t * pTransport,
         returnStatus = addContentLengthHeader( pRequestHeaders, reqBodyLen );
     }
 
-    if( returnStatus == HTTP_SUCCESS )
+    if( returnStatus == HTTPSuccess )
     {
         /* Send the HTTP headers over the network. */
         if( pRequestHeaders->headersLen > INT32_MAX )
@@ -1745,7 +1745,7 @@ static HTTPStatus_t sendHttpBody( const TransportInterface_t * pTransport,
                                   const uint8_t * pRequestBodyBuf,
                                   size_t reqBodyBufLen )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
 
     assert( pTransport != NULL );
     assert( pTransport->send != NULL );
@@ -1766,7 +1766,7 @@ static HTTPStatus_t receiveHttpData( const TransportInterface_t * pTransport,
                                      size_t bufferLen,
                                      size_t * pBytesReceived )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
     int32_t transportStatus = 0;
 
     assert( pTransport != NULL );
@@ -1817,7 +1817,7 @@ static HTTPStatus_t getFinalResponseStatus( HTTPParsingState_t parsingState,
                                             size_t totalReceived,
                                             size_t responseBufferLen )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
 
     assert( parsingState >= HTTP_PARSING_NONE &&
             parsingState <= HTTP_PARSING_COMPLETE );
@@ -1864,7 +1864,7 @@ static HTTPStatus_t receiveAndParseHttpResponse( const TransportInterface_t * pT
                                                  HTTPResponse_t * pResponse,
                                                  const HTTPRequestHeaders_t * pRequestHeaders )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
     size_t totalReceived = 0u;
     size_t currentReceived = 0u;
     HTTPParsingContext_t parsingContext = { 0 };
@@ -1900,7 +1900,7 @@ static HTTPStatus_t receiveAndParseHttpResponse( const TransportInterface_t * pT
                                         pResponse->bufferLen - totalReceived,
                                         &currentReceived );
 
-        if( returnStatus == HTTP_SUCCESS )
+        if( returnStatus == HTTPSuccess )
         {
             /* Data is received into the buffer and must be parsed. Parsing is
              * invoked even with a length of zero. A length of zero indicates to
@@ -1916,13 +1916,13 @@ static HTTPStatus_t receiveAndParseHttpResponse( const TransportInterface_t * pT
          * or parsing, non-zero data was received from the network,
          * the parser indicated the response message is not finished, and there
          * is room in the response buffer. */
-        shouldRecv = ( ( returnStatus == HTTP_SUCCESS ) &&
+        shouldRecv = ( ( returnStatus == HTTPSuccess ) &&
                        ( currentReceived > 0u ) &&
                        ( parsingContext.state != HTTP_PARSING_COMPLETE ) &&
                        ( totalReceived < pResponse->bufferLen ) ) ? 1u : 0u;
     }
 
-    if( returnStatus == HTTP_SUCCESS )
+    if( returnStatus == HTTPSuccess )
     {
         /* If there are errors in receiving from the network or during parsing,
          * the final status of the response message is derived from the state of
@@ -1944,7 +1944,7 @@ HTTPStatus_t HTTPClient_Send( const TransportInterface_t * pTransport,
                               HTTPResponse_t * pResponse,
                               uint32_t sendFlags )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
 
     if( pTransport == NULL )
     {
@@ -2011,7 +2011,7 @@ HTTPStatus_t HTTPClient_Send( const TransportInterface_t * pTransport,
     }
 
     /* Send the headers, which are at one location in memory. */
-    if( returnStatus == HTTP_SUCCESS )
+    if( returnStatus == HTTPSuccess )
     {
         returnStatus = sendHttpHeaders( pTransport,
                                         pRequestHeaders,
@@ -2020,7 +2020,7 @@ HTTPStatus_t HTTPClient_Send( const TransportInterface_t * pTransport,
     }
 
     /* Send the body, which is at another location in memory. */
-    if( returnStatus == HTTP_SUCCESS )
+    if( returnStatus == HTTPSuccess )
     {
         if( pRequestBodyBuf != NULL )
         {
@@ -2034,7 +2034,7 @@ HTTPStatus_t HTTPClient_Send( const TransportInterface_t * pTransport,
         }
     }
 
-    if( returnStatus == HTTP_SUCCESS )
+    if( returnStatus == HTTPSuccess )
     {
         /* If the application chooses to receive a response, then pResponse
          * will not be NULL. */
@@ -2176,7 +2176,7 @@ static HTTPStatus_t findHeaderInResponse( const uint8_t * pBuffer,
                                           const char ** pValueLoc,
                                           size_t * pValueLen )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
     http_parser parser = { 0 };
     http_parser_settings parserSettings = { 0 };
     findHeaderContext_t context = { 0 };
@@ -2257,7 +2257,7 @@ static HTTPStatus_t findHeaderInResponse( const uint8_t * pBuffer,
     /* If the header field-value pair is found in response, then the return
      * value of "on_header_value" callback (related to the header value) should
      * cause the http_parser.http_errno to be "CB_header_value". */
-    if( ( returnStatus == HTTP_SUCCESS ) &&
+    if( ( returnStatus == HTTPSuccess ) &&
         ( parser.http_errno != ( unsigned int ) HPE_CB_header_value ) )
     {
         LogError( ( "Header found in response but http-parser returned error: "
@@ -2293,7 +2293,7 @@ HTTPStatus_t HTTPClient_ReadHeader( const HTTPResponse_t * pResponse,
                                     const char ** pValueLoc,
                                     size_t * pValueLen )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
 
     if( pResponse == NULL )
     {
@@ -2337,7 +2337,7 @@ HTTPStatus_t HTTPClient_ReadHeader( const HTTPResponse_t * pResponse,
         /* Empty else for MISRA 15.7 compliance. */
     }
 
-    if( returnStatus == HTTP_SUCCESS )
+    if( returnStatus == HTTPSuccess )
     {
         returnStatus = findHeaderInResponse( pResponse->pBuffer,
                                              pResponse->bufferLen,
@@ -2358,8 +2358,8 @@ const char * HTTPClient_strerror( HTTPStatus_t status )
 
     switch( status )
     {
-        case HTTP_SUCCESS:
-            str = "HTTP_SUCCESS";
+        case HTTPSuccess:
+            str = "HTTPSuccess";
             break;
 
         case HTTP_INVALID_PARAMETER:

--- a/source/core_http_client.c
+++ b/source/core_http_client.c
@@ -503,7 +503,7 @@ static void processCompleteHeader( HTTPParsingContext_t * pParsingContext );
  * - #HTTPSecurityAlertInvalidProtocolVersion
  * - #HTTPSecurityAlertInvalidStatusCode
  * - #HTTPSecurityAlertInvalidCharacter
- * - #HTTP_SECURITY_ALERT_INVALID_CONTENT_LENGTH
+ * - #HTTPSecurityAlertInvalidContentLength
  * - #HTTP_PARSER_INTERNAL_ERROR
  */
 static HTTPStatus_t processHttpParserError( const http_parser * pHttpParser );
@@ -1015,13 +1015,13 @@ static HTTPStatus_t processHttpParserError( const http_parser * pHttpParser )
              * character and location. */
             LogError( ( "Response parsing error: Invalid character found in "
                         "content-length headers." ) );
-            returnStatus = HTTP_SECURITY_ALERT_INVALID_CONTENT_LENGTH;
+            returnStatus = HTTPSecurityAlertInvalidContentLength;
             break;
 
         case HPE_UNEXPECTED_CONTENT_LENGTH:
             LogError( ( "Response parsing error: A Content-Length header was "
                         "found when it shouldn't have been." ) );
-            returnStatus = HTTP_SECURITY_ALERT_INVALID_CONTENT_LENGTH;
+            returnStatus = HTTPSecurityAlertInvalidContentLength;
             break;
 
         /* All other error cases cannot be triggered and indicate an error in the
@@ -2406,8 +2406,8 @@ const char * HTTPClient_strerror( HTTPStatus_t status )
             str = "HTTPSecurityAlertInvalidCharacter";
             break;
 
-        case HTTP_SECURITY_ALERT_INVALID_CONTENT_LENGTH:
-            str = "HTTP_SECURITY_ALERT_INVALID_CONTENT_LENGTH";
+        case HTTPSecurityAlertInvalidContentLength:
+            str = "HTTPSecurityAlertInvalidContentLength";
             break;
 
         case HTTP_PARSER_INTERNAL_ERROR:

--- a/source/core_http_client.c
+++ b/source/core_http_client.c
@@ -230,7 +230,7 @@ static HTTPStatus_t writeRequestLine( HTTPRequestHeaders_t * pRequestHeaders,
  * @return One of the following:
  * - #HTTPSuccess when header is found in the response.
  * - #HTTPHeaderNotFound if requested header is not found in response.
- * - #HTTP_INVALID_RESPONSE if passed response is invalid for parsing.
+ * - #HTTPInvalidResponse if passed response is invalid for parsing.
  * - #HTTPParserInternalError for any parsing errors.
  */
 static HTTPStatus_t findHeaderInResponse( const uint8_t * pBuffer,
@@ -2236,7 +2236,7 @@ static HTTPStatus_t findHeaderInResponse( const uint8_t * pBuffer,
                     ( int ) fieldLen,
                     pField,
                     http_errno_description( HTTP_PARSER_ERRNO( &( parser ) ) ) ) );
-        returnStatus = HTTP_INVALID_RESPONSE;
+        returnStatus = HTTPInvalidResponse;
     }
     else
     {
@@ -2275,7 +2275,7 @@ static HTTPStatus_t findHeaderInResponse( const uint8_t * pBuffer,
         LogError( ( "Header not found in response: http-parser returned error: "
                     "ParserError=%s",
                     http_errno_description( HTTP_PARSER_ERRNO( &( parser ) ) ) ) );
-        returnStatus = HTTP_INVALID_RESPONSE;
+        returnStatus = HTTPInvalidResponse;
     }
     else
     {
@@ -2418,8 +2418,8 @@ const char * HTTPClient_strerror( HTTPStatus_t status )
             str = "HTTPHeaderNotFound";
             break;
 
-        case HTTP_INVALID_RESPONSE:
-            str = "HTTP_INVALID_RESPONSE";
+        case HTTPInvalidResponse:
+            str = "HTTPInvalidResponse";
             break;
 
         default:

--- a/source/core_http_client.c
+++ b/source/core_http_client.c
@@ -502,7 +502,7 @@ static void processCompleteHeader( HTTPParsingContext_t * pParsingContext );
  * - #HTTPSecurityAlertInvalidChunkHeader
  * - #HTTPSecurityAlertInvalidProtocolVersion
  * - #HTTPSecurityAlertInvalidStatusCode
- * - #HTTP_SECURITY_ALERT_INVALID_CHARACTER
+ * - #HTTPSecurityAlertInvalidCharacter
  * - #HTTP_SECURITY_ALERT_INVALID_CONTENT_LENGTH
  * - #HTTP_PARSER_INTERNAL_ERROR
  */
@@ -991,13 +991,13 @@ static HTTPStatus_t processHttpParserError( const http_parser * pHttpParser )
         case HPE_INVALID_CONSTANT:
             LogError( ( "Response parsing error: Invalid character found in "
                         "Status-Line or header delimiters." ) );
-            returnStatus = HTTP_SECURITY_ALERT_INVALID_CHARACTER;
+            returnStatus = HTTPSecurityAlertInvalidCharacter;
             break;
 
         case HPE_LF_EXPECTED:
             LogError( ( "Response parsing error: Expected line-feed in header "
                         "not found." ) );
-            returnStatus = HTTP_SECURITY_ALERT_INVALID_CHARACTER;
+            returnStatus = HTTPSecurityAlertInvalidCharacter;
             break;
 
         case HPE_INVALID_HEADER_TOKEN:
@@ -1006,7 +1006,7 @@ static HTTPStatus_t processHttpParserError( const http_parser * pHttpParser )
              * character and location. */
             LogError( ( "Response parsing error: Invalid character found in "
                         "headers." ) );
-            returnStatus = HTTP_SECURITY_ALERT_INVALID_CHARACTER;
+            returnStatus = HTTPSecurityAlertInvalidCharacter;
             break;
 
         case HPE_INVALID_CONTENT_LENGTH:
@@ -2402,8 +2402,8 @@ const char * HTTPClient_strerror( HTTPStatus_t status )
             str = "HTTPSecurityAlertInvalidStatusCode";
             break;
 
-        case HTTP_SECURITY_ALERT_INVALID_CHARACTER:
-            str = "HTTP_SECURITY_ALERT_INVALID_CHARACTER";
+        case HTTPSecurityAlertInvalidCharacter:
+            str = "HTTPSecurityAlertInvalidCharacter";
             break;
 
         case HTTP_SECURITY_ALERT_INVALID_CONTENT_LENGTH:

--- a/source/core_http_client.c
+++ b/source/core_http_client.c
@@ -229,7 +229,7 @@ static HTTPStatus_t writeRequestLine( HTTPRequestHeaders_t * pRequestHeaders,
  *
  * @return One of the following:
  * - #HTTPSuccess when header is found in the response.
- * - #HTTP_HEADER_NOT_FOUND if requested header is not found in response.
+ * - #HTTPHeaderNotFound if requested header is not found in response.
  * - #HTTP_INVALID_RESPONSE if passed response is invalid for parsing.
  * - #HTTPParserInternalError for any parsing errors.
  */
@@ -2224,7 +2224,7 @@ static HTTPStatus_t findHeaderInResponse( const uint8_t * pBuffer,
                    ( int ) fieldLen,
                    pField ) );
 
-        returnStatus = HTTP_HEADER_NOT_FOUND;
+        returnStatus = HTTPHeaderNotFound;
     }
     else if( context.valueFound == 0u )
     {
@@ -2269,7 +2269,7 @@ static HTTPStatus_t findHeaderInResponse( const uint8_t * pBuffer,
     /* If header was not found, then the "on_header_complete" callback is
      * expected to be called which should cause the http_parser.http_errno to be
      * "OK" */
-    else if( ( returnStatus == HTTP_HEADER_NOT_FOUND ) &&
+    else if( ( returnStatus == HTTPHeaderNotFound ) &&
              ( parser.http_errno != ( unsigned int ) ( HPE_OK ) ) )
     {
         LogError( ( "Header not found in response: http-parser returned error: "
@@ -2414,8 +2414,8 @@ const char * HTTPClient_strerror( HTTPStatus_t status )
             str = "HTTPParserInternalError";
             break;
 
-        case HTTP_HEADER_NOT_FOUND:
-            str = "HTTP_HEADER_NOT_FOUND";
+        case HTTPHeaderNotFound:
+            str = "HTTPHeaderNotFound";
             break;
 
         case HTTP_INVALID_RESPONSE:

--- a/source/core_http_client.c
+++ b/source/core_http_client.c
@@ -497,7 +497,7 @@ static void processCompleteHeader( HTTPParsingContext_t * pParsingContext );
  *
  * @return One of the following:
  * - #HTTPSuccess
- * - #HTTP_SECURITY_ALERT_RESPONSE_HEADERS_SIZE_LIMIT_EXCEEDED
+ * - #HTTPSecurityAlertResponseHeadersSizeLimitExceeded
  * - #HTTP_SECURITY_ALERT_EXTRANEOUS_RESPONSE_DATA
  * - #HTTP_SECURITY_ALERT_INVALID_CHUNK_HEADER
  * - #HTTP_SECURITY_ALERT_INVALID_PROTOCOL_VERSION
@@ -951,7 +951,7 @@ static HTTPStatus_t processHttpParserError( const http_parser * pHttpParser )
             LogError( ( "Response parsing error: Header byte limit "
                         "exceeded: HeaderByteLimit=%d",
                         HTTP_MAX_RESPONSE_HEADERS_SIZE_BYTES ) );
-            returnStatus = HTTP_SECURITY_ALERT_RESPONSE_HEADERS_SIZE_LIMIT_EXCEEDED;
+            returnStatus = HTTPSecurityAlertResponseHeadersSizeLimitExceeded;
             break;
 
         case HPE_CLOSED_CONNECTION:
@@ -2382,8 +2382,8 @@ const char * HTTPClient_strerror( HTTPStatus_t status )
             str = "HTTPInsufficientMemory";
             break;
 
-        case HTTP_SECURITY_ALERT_RESPONSE_HEADERS_SIZE_LIMIT_EXCEEDED:
-            str = "HTTP_SECURITY_ALERT_RESPONSE_HEADERS_SIZE_LIMIT_EXCEEDED";
+        case HTTPSecurityAlertResponseHeadersSizeLimitExceeded:
+            str = "HTTPSecurityAlertResponseHeadersSizeLimitExceeded";
             break;
 
         case HTTP_SECURITY_ALERT_EXTRANEOUS_RESPONSE_DATA:

--- a/source/core_http_client.c
+++ b/source/core_http_client.c
@@ -231,7 +231,7 @@ static HTTPStatus_t writeRequestLine( HTTPRequestHeaders_t * pRequestHeaders,
  * - #HTTPSuccess when header is found in the response.
  * - #HTTP_HEADER_NOT_FOUND if requested header is not found in response.
  * - #HTTP_INVALID_RESPONSE if passed response is invalid for parsing.
- * - #HTTP_PARSER_INTERNAL_ERROR for any parsing errors.
+ * - #HTTPParserInternalError for any parsing errors.
  */
 static HTTPStatus_t findHeaderInResponse( const uint8_t * pBuffer,
                                           size_t bufferLen,
@@ -504,7 +504,7 @@ static void processCompleteHeader( HTTPParsingContext_t * pParsingContext );
  * - #HTTPSecurityAlertInvalidStatusCode
  * - #HTTPSecurityAlertInvalidCharacter
  * - #HTTPSecurityAlertInvalidContentLength
- * - #HTTP_PARSER_INTERNAL_ERROR
+ * - #HTTPParserInternalError
  */
 static HTTPStatus_t processHttpParserError( const http_parser * pHttpParser );
 
@@ -1028,7 +1028,7 @@ static HTTPStatus_t processHttpParserError( const http_parser * pHttpParser )
          * third-party parsing library if found. */
         default:
             LogError( ( "Error in third-party http-parser library." ) );
-            returnStatus = HTTP_PARSER_INTERNAL_ERROR;
+            returnStatus = HTTPParserInternalError;
             break;
     }
 
@@ -2263,7 +2263,7 @@ static HTTPStatus_t findHeaderInResponse( const uint8_t * pBuffer,
         LogError( ( "Header found in response but http-parser returned error: "
                     "ParserError=%s",
                     http_errno_description( HTTP_PARSER_ERRNO( &( parser ) ) ) ) );
-        returnStatus = HTTP_PARSER_INTERNAL_ERROR;
+        returnStatus = HTTPParserInternalError;
     }
 
     /* If header was not found, then the "on_header_complete" callback is
@@ -2410,8 +2410,8 @@ const char * HTTPClient_strerror( HTTPStatus_t status )
             str = "HTTPSecurityAlertInvalidContentLength";
             break;
 
-        case HTTP_PARSER_INTERNAL_ERROR:
-            str = "HTTP_PARSER_INTERNAL_ERROR";
+        case HTTPParserInternalError:
+            str = "HTTPParserInternalError";
             break;
 
         case HTTP_HEADER_NOT_FOUND:

--- a/source/core_http_client.c
+++ b/source/core_http_client.c
@@ -501,7 +501,7 @@ static void processCompleteHeader( HTTPParsingContext_t * pParsingContext );
  * - #HTTPSecurityAlertExtraneousResponseData
  * - #HTTPSecurityAlertInvalidChunkHeader
  * - #HTTPSecurityAlertInvalidProtocolVersion
- * - #HTTP_SECURITY_ALERT_INVALID_STATUS_CODE
+ * - #HTTPSecurityAlertInvalidStatusCode
  * - #HTTP_SECURITY_ALERT_INVALID_CHARACTER
  * - #HTTP_SECURITY_ALERT_INVALID_CONTENT_LENGTH
  * - #HTTP_PARSER_INTERNAL_ERROR
@@ -984,7 +984,7 @@ static HTTPStatus_t processHttpParserError( const http_parser * pHttpParser )
              * could be out of range. This feedback is not given back by the
              * http-parser library. */
             LogError( ( "Response parsing error: Invalid Status code." ) );
-            returnStatus = HTTP_SECURITY_ALERT_INVALID_STATUS_CODE;
+            returnStatus = HTTPSecurityAlertInvalidStatusCode;
             break;
 
         case HPE_STRICT:
@@ -2398,8 +2398,8 @@ const char * HTTPClient_strerror( HTTPStatus_t status )
             str = "HTTPSecurityAlertInvalidProtocolVersion";
             break;
 
-        case HTTP_SECURITY_ALERT_INVALID_STATUS_CODE:
-            str = "HTTP_SECURITY_ALERT_INVALID_STATUS_CODE";
+        case HTTPSecurityAlertInvalidStatusCode:
+            str = "HTTPSecurityAlertInvalidStatusCode";
             break;
 
         case HTTP_SECURITY_ALERT_INVALID_CHARACTER:

--- a/source/core_http_client.c
+++ b/source/core_http_client.c
@@ -498,7 +498,7 @@ static void processCompleteHeader( HTTPParsingContext_t * pParsingContext );
  * @return One of the following:
  * - #HTTPSuccess
  * - #HTTPSecurityAlertResponseHeadersSizeLimitExceeded
- * - #HTTP_SECURITY_ALERT_EXTRANEOUS_RESPONSE_DATA
+ * - #HTTPSecurityAlertExtraneousResponseData
  * - #HTTP_SECURITY_ALERT_INVALID_CHUNK_HEADER
  * - #HTTP_SECURITY_ALERT_INVALID_PROTOCOL_VERSION
  * - #HTTP_SECURITY_ALERT_INVALID_STATUS_CODE
@@ -957,7 +957,7 @@ static HTTPStatus_t processHttpParserError( const http_parser * pHttpParser )
         case HPE_CLOSED_CONNECTION:
             LogError( ( "Response parsing error: Data received past complete "
                         "response with \"Connection: close\" header present." ) );
-            returnStatus = HTTP_SECURITY_ALERT_EXTRANEOUS_RESPONSE_DATA;
+            returnStatus = HTTPSecurityAlertExtraneousResponseData;
             break;
 
         case HPE_INVALID_CHUNK_SIZE:
@@ -2386,8 +2386,8 @@ const char * HTTPClient_strerror( HTTPStatus_t status )
             str = "HTTPSecurityAlertResponseHeadersSizeLimitExceeded";
             break;
 
-        case HTTP_SECURITY_ALERT_EXTRANEOUS_RESPONSE_DATA:
-            str = "HTTP_SECURITY_ALERT_EXTRANEOUS_RESPONSE_DATA";
+        case HTTPSecurityAlertExtraneousResponseData:
+            str = "HTTPSecurityAlertExtraneousResponseData";
             break;
 
         case HTTP_SECURITY_ALERT_INVALID_CHUNK_HEADER:

--- a/source/core_http_client.c
+++ b/source/core_http_client.c
@@ -41,7 +41,7 @@
  * @param[in] dataLen HTTP request data length.
  *
  * @return #HTTPSuccess if successful. If there was a network error or less
- * bytes than what were specified were sent, then #HTTP_NETWORK_ERROR is
+ * bytes than what were specified were sent, then #HTTPNetworkError is
  * returned.
  */
 static HTTPStatus_t sendHttpData( const TransportInterface_t * pTransport,
@@ -59,7 +59,7 @@ static HTTPStatus_t sendHttpData( const TransportInterface_t * pTransport,
  * @param[in] sendFlags Application provided flags to #HTTPClient_Send.
  *
  * @return #HTTPSuccess if successful. If there was a network error or less
- * bytes than what were specified were sent, then #HTTP_NETWORK_ERROR is
+ * bytes than what were specified were sent, then #HTTPNetworkError is
  * returned.
  */
 static HTTPStatus_t sendHttpHeaders( const TransportInterface_t * pTransport,
@@ -88,7 +88,7 @@ static HTTPStatus_t addContentLengthHeader( HTTPRequestHeaders_t * pRequestHeade
  * @param[in] reqBodyBufLen Length of the request body buffer.
  *
  * @return #HTTPSuccess if successful. If there was a network error or less
- * bytes than what was specified were sent, then #HTTP_NETWORK_ERROR is
+ * bytes than what was specified were sent, then #HTTPNetworkError is
  * returned.
  */
 static HTTPStatus_t sendHttpBody( const TransportInterface_t * pTransport,
@@ -142,7 +142,7 @@ static HTTPStatus_t addRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
  * @param[out] pBytesReceived Bytes received from the transport interface.
  *
  * @return Returns #HTTPSuccess if successful. If there was a network error or
- * more bytes than what was specified were read, then #HTTP_NETWORK_ERROR is
+ * more bytes than what was specified were read, then #HTTPNetworkError is
  * returned.
  */
 static HTTPStatus_t receiveHttpData( const TransportInterface_t * pTransport,
@@ -1622,7 +1622,7 @@ static HTTPStatus_t sendHttpData( const TransportInterface_t * pTransport,
     assert( pData != NULL );
 
     /* Loop until all data is sent. */
-    while( ( bytesRemaining > 0UL ) && ( returnStatus != HTTP_NETWORK_ERROR ) )
+    while( ( bytesRemaining > 0UL ) && ( returnStatus != HTTPNetworkError ) )
     {
         transportStatus = pTransport->send( pTransport->pNetworkContext,
                                             pIndex,
@@ -1634,7 +1634,7 @@ static HTTPStatus_t sendHttpData( const TransportInterface_t * pTransport,
             LogError( ( "Failed to send HTTP data: Transport send()"
                         " returned error: TransportStatus=%d",
                         transportStatus ) );
-            returnStatus = HTTP_NETWORK_ERROR;
+            returnStatus = HTTPNetworkError;
         }
         else
         {
@@ -1784,7 +1784,7 @@ static HTTPStatus_t receiveHttpData( const TransportInterface_t * pTransport,
         LogError( ( "Failed to receive HTTP data: Transport recv() "
                     "returned error: TransportStatus=%d",
                     transportStatus ) );
-        returnStatus = HTTP_NETWORK_ERROR;
+        returnStatus = HTTPNetworkError;
     }
     else if( transportStatus > 0 )
     {
@@ -2366,8 +2366,8 @@ const char * HTTPClient_strerror( HTTPStatus_t status )
             str = "HTTPInvalidParameter";
             break;
 
-        case HTTP_NETWORK_ERROR:
-            str = "HTTP_NETWORK_ERROR";
+        case HTTPNetworkError:
+            str = "HTTPNetworkError";
             break;
 
         case HTTP_PARTIAL_RESPONSE:

--- a/source/core_http_client.c
+++ b/source/core_http_client.c
@@ -160,7 +160,7 @@ static HTTPStatus_t receiveHttpData( const TransportInterface_t * pTransport,
  * @param[in] responseBufferLen The length of the response buffer.
  *
  * @return Returns #HTTPSuccess if the parsing state is complete. If
- * the parsing state denotes it never started, then return #HTTP_NO_RESPONSE. If
+ * the parsing state denotes it never started, then return #HTTPNoResponse. If
  * the parsing state is incomplete, then if the response buffer is not full
  * #HTTPPartialResponse is returned. If the parsing state is incomplete, then
  * if the response buffer is full #HTTP_INSUFFICIENT_MEMORY is returned.
@@ -1829,7 +1829,7 @@ static HTTPStatus_t getFinalResponseStatus( HTTPParsingState_t parsingState,
         LogError( ( "Response not received: Zero returned from "
                     "transport recv: totalReceived=%lu",
                     ( unsigned long ) totalReceived ) );
-        returnStatus = HTTP_NO_RESPONSE;
+        returnStatus = HTTPNoResponse;
     }
     else if( parsingState == HTTP_PARSING_INCOMPLETE )
     {
@@ -2374,8 +2374,8 @@ const char * HTTPClient_strerror( HTTPStatus_t status )
             str = "HTTPPartialResponse";
             break;
 
-        case HTTP_NO_RESPONSE:
-            str = "HTTP_NO_RESPONSE";
+        case HTTPNoResponse:
+            str = "HTTPNoResponse";
             break;
 
         case HTTP_INSUFFICIENT_MEMORY:

--- a/source/core_http_client.c
+++ b/source/core_http_client.c
@@ -315,7 +315,7 @@ static void initializeParsingContextForFirstResponse( HTTPParsingContext_t * pPa
  *
  * @return One of the following:
  * - #HTTPSuccess
- * - #HTTP_INVALID_PARAMETER
+ * - #HTTPInvalidParameter
  * - Please see #processHttpParserError for parsing errors returned.
  */
 static HTTPStatus_t parseHttpResponse( HTTPParsingContext_t * pParsingContext,
@@ -1395,37 +1395,37 @@ HTTPStatus_t HTTPClient_InitializeRequestHeaders( HTTPRequestHeaders_t * pReques
     if( pRequestHeaders == NULL )
     {
         LogError( ( "Parameter check failed: pRequestHeaders is NULL." ) );
-        returnStatus = HTTP_INVALID_PARAMETER;
+        returnStatus = HTTPInvalidParameter;
     }
     else if( pRequestHeaders->pBuffer == NULL )
     {
         LogError( ( "Parameter check failed: pRequestHeaders->pBuffer is NULL." ) );
-        returnStatus = HTTP_INVALID_PARAMETER;
+        returnStatus = HTTPInvalidParameter;
     }
     else if( pRequestInfo == NULL )
     {
         LogError( ( "Parameter check failed: pRequestInfo is NULL." ) );
-        returnStatus = HTTP_INVALID_PARAMETER;
+        returnStatus = HTTPInvalidParameter;
     }
     else if( pRequestInfo->method == NULL )
     {
         LogError( ( "Parameter check failed: pRequestInfo->method is NULL." ) );
-        returnStatus = HTTP_INVALID_PARAMETER;
+        returnStatus = HTTPInvalidParameter;
     }
     else if( pRequestInfo->pHost == NULL )
     {
         LogError( ( "Parameter check failed: pRequestInfo->pHost is NULL." ) );
-        returnStatus = HTTP_INVALID_PARAMETER;
+        returnStatus = HTTPInvalidParameter;
     }
     else if( pRequestInfo->methodLen == 0u )
     {
         LogError( ( "Parameter check failed: pRequestInfo->methodLen must be greater than 0." ) );
-        returnStatus = HTTP_INVALID_PARAMETER;
+        returnStatus = HTTPInvalidParameter;
     }
     else if( pRequestInfo->hostLen == 0u )
     {
         LogError( ( "Parameter check failed: pRequestInfo->hostLen must be greater than 0." ) );
-        returnStatus = HTTP_INVALID_PARAMETER;
+        returnStatus = HTTPInvalidParameter;
     }
     else
     {
@@ -1495,37 +1495,37 @@ HTTPStatus_t HTTPClient_AddHeader( HTTPRequestHeaders_t * pRequestHeaders,
     if( pRequestHeaders == NULL )
     {
         LogError( ( "Parameter check failed: pRequestHeaders is NULL." ) );
-        returnStatus = HTTP_INVALID_PARAMETER;
+        returnStatus = HTTPInvalidParameter;
     }
     else if( pRequestHeaders->pBuffer == NULL )
     {
         LogError( ( "Parameter check failed: pRequestHeaders->pBuffer is NULL." ) );
-        returnStatus = HTTP_INVALID_PARAMETER;
+        returnStatus = HTTPInvalidParameter;
     }
     else if( pField == NULL )
     {
         LogError( ( "Parameter check failed: pField is NULL." ) );
-        returnStatus = HTTP_INVALID_PARAMETER;
+        returnStatus = HTTPInvalidParameter;
     }
     else if( pValue == NULL )
     {
         LogError( ( "Parameter check failed: pValue is NULL." ) );
-        returnStatus = HTTP_INVALID_PARAMETER;
+        returnStatus = HTTPInvalidParameter;
     }
     else if( fieldLen == 0u )
     {
         LogError( ( "Parameter check failed: fieldLen must be greater than 0." ) );
-        returnStatus = HTTP_INVALID_PARAMETER;
+        returnStatus = HTTPInvalidParameter;
     }
     else if( valueLen == 0u )
     {
         LogError( ( "Parameter check failed: valueLen must be greater than 0." ) );
-        returnStatus = HTTP_INVALID_PARAMETER;
+        returnStatus = HTTPInvalidParameter;
     }
     else if( pRequestHeaders->headersLen > pRequestHeaders->bufferLen )
     {
         LogError( ( "Parameter check failed: pRequestHeaders->headersLen > pRequestHeaders->bufferLen." ) );
-        returnStatus = HTTP_INVALID_PARAMETER;
+        returnStatus = HTTPInvalidParameter;
     }
     else
     {
@@ -1552,23 +1552,23 @@ HTTPStatus_t HTTPClient_AddRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
     if( pRequestHeaders == NULL )
     {
         LogError( ( "Parameter check failed: pRequestHeaders is NULL." ) );
-        returnStatus = HTTP_INVALID_PARAMETER;
+        returnStatus = HTTPInvalidParameter;
     }
     else if( pRequestHeaders->pBuffer == NULL )
     {
         LogError( ( "Parameter check failed: pRequestHeaders->pBuffer is NULL." ) );
-        returnStatus = HTTP_INVALID_PARAMETER;
+        returnStatus = HTTPInvalidParameter;
     }
     else if( pRequestHeaders->headersLen > pRequestHeaders->bufferLen )
     {
         LogError( ( "Parameter check failed: pRequestHeaders->headersLen > pRequestHeaders->bufferLen." ) );
-        returnStatus = HTTP_INVALID_PARAMETER;
+        returnStatus = HTTPInvalidParameter;
     }
     else if( rangeEnd < HTTP_RANGE_REQUEST_END_OF_FILE )
     {
         LogError( ( "Parameter check failed: rangeEnd is invalid: "
                     "rangeEnd should be >=-1: RangeEnd=%d", rangeEnd ) );
-        returnStatus = HTTP_INVALID_PARAMETER;
+        returnStatus = HTTPInvalidParameter;
     }
     else if( ( rangeStartOrlastNbytes < 0 ) &&
              ( rangeEnd != HTTP_RANGE_REQUEST_END_OF_FILE ) )
@@ -1577,7 +1577,7 @@ HTTPStatus_t HTTPClient_AddRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
                     "rangeEnd should be -1 when rangeStart < 0: "
                     "RangeStart=%d, RangeEnd=%d",
                     rangeStartOrlastNbytes, rangeEnd ) );
-        returnStatus = HTTP_INVALID_PARAMETER;
+        returnStatus = HTTPInvalidParameter;
     }
     else if( ( rangeEnd != HTTP_RANGE_REQUEST_END_OF_FILE ) &&
              ( rangeStartOrlastNbytes > rangeEnd ) )
@@ -1586,7 +1586,7 @@ HTTPStatus_t HTTPClient_AddRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
                     "rangeStart should be < rangeEnd when both are >= 0: "
                     "RangeStart=%d, RangeEnd=%d",
                     rangeStartOrlastNbytes, rangeEnd ) );
-        returnStatus = HTTP_INVALID_PARAMETER;
+        returnStatus = HTTPInvalidParameter;
     }
     else if( rangeStartOrlastNbytes == INT32_MIN )
     {
@@ -1594,7 +1594,7 @@ HTTPStatus_t HTTPClient_AddRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
                     "rangeStart should be > -2147483648 (INT32_MIN): "
                     "RangeStart=%d",
                     rangeStartOrlastNbytes ) );
-        returnStatus = HTTP_INVALID_PARAMETER;
+        returnStatus = HTTPInvalidParameter;
     }
     else
     {
@@ -1726,7 +1726,7 @@ static HTTPStatus_t sendHttpHeaders( const TransportInterface_t * pTransport,
         {
             LogError( ( "Parameter check failed: pRequestHeaders->headersLen > "
                         "2147483647 (INT32_MAX)." ) );
-            returnStatus = HTTP_INVALID_PARAMETER;
+            returnStatus = HTTPInvalidParameter;
         }
         else
         {
@@ -1949,27 +1949,27 @@ HTTPStatus_t HTTPClient_Send( const TransportInterface_t * pTransport,
     if( pTransport == NULL )
     {
         LogError( ( "Parameter check failed: pTransport interface is NULL." ) );
-        returnStatus = HTTP_INVALID_PARAMETER;
+        returnStatus = HTTPInvalidParameter;
     }
     else if( pTransport->send == NULL )
     {
         LogError( ( "Parameter check failed: pTransport->send is NULL." ) );
-        returnStatus = HTTP_INVALID_PARAMETER;
+        returnStatus = HTTPInvalidParameter;
     }
     else if( pTransport->recv == NULL )
     {
         LogError( ( "Parameter check failed: pTransport->recv is NULL." ) );
-        returnStatus = HTTP_INVALID_PARAMETER;
+        returnStatus = HTTPInvalidParameter;
     }
     else if( pRequestHeaders == NULL )
     {
         LogError( ( "Parameter check failed: pRequestHeaders is NULL." ) );
-        returnStatus = HTTP_INVALID_PARAMETER;
+        returnStatus = HTTPInvalidParameter;
     }
     else if( pRequestHeaders->pBuffer == NULL )
     {
         LogError( ( "Parameter check failed: pRequestHeaders->pBuffer is NULL." ) );
-        returnStatus = HTTP_INVALID_PARAMETER;
+        returnStatus = HTTPInvalidParameter;
     }
     else if( pRequestHeaders->headersLen < HTTP_MINIMUM_REQUEST_LINE_LENGTH )
     {
@@ -1978,24 +1978,24 @@ HTTPStatus_t HTTPClient_Send( const TransportInterface_t * pTransport,
                     "MinimumRequiredLength=%u, HeadersLength =%lu",
                     HTTP_MINIMUM_REQUEST_LINE_LENGTH,
                     ( unsigned long ) ( pRequestHeaders->headersLen ) ) );
-        returnStatus = HTTP_INVALID_PARAMETER;
+        returnStatus = HTTPInvalidParameter;
     }
     else if( pRequestHeaders->headersLen > pRequestHeaders->bufferLen )
     {
         LogError( ( "Parameter check failed: pRequestHeaders->headersLen > "
                     "pRequestHeaders->bufferLen." ) );
-        returnStatus = HTTP_INVALID_PARAMETER;
+        returnStatus = HTTPInvalidParameter;
     }
     else if( ( pResponse != NULL ) && ( pResponse->pBuffer == NULL ) )
     {
         LogError( ( "Parameter check failed: pResponse->pBuffer is NULL." ) );
-        returnStatus = HTTP_INVALID_PARAMETER;
+        returnStatus = HTTPInvalidParameter;
     }
     else if( ( pRequestBodyBuf == NULL ) && ( reqBodyBufLen > 0u ) )
     {
         LogError( ( "Parameter check failed: pRequestBodyBuf is NULL, but "
                     "reqBodyBufLen is greater than zero." ) );
-        returnStatus = HTTP_INVALID_PARAMETER;
+        returnStatus = HTTPInvalidParameter;
     }
     else if( reqBodyBufLen > INT32_MAX )
     {
@@ -2003,7 +2003,7 @@ HTTPStatus_t HTTPClient_Send( const TransportInterface_t * pTransport,
          * reqBodyBufLen to create a Content-Length header value string. */
         LogError( ( "Parameter check failed: reqBodyBufLen > "
                     "2147483647 (INT32_MAX)." ) );
-        returnStatus = HTTP_INVALID_PARAMETER;
+        returnStatus = HTTPInvalidParameter;
     }
     else
     {
@@ -2298,39 +2298,39 @@ HTTPStatus_t HTTPClient_ReadHeader( const HTTPResponse_t * pResponse,
     if( pResponse == NULL )
     {
         LogError( ( "Parameter check failed: pResponse is NULL." ) );
-        returnStatus = HTTP_INVALID_PARAMETER;
+        returnStatus = HTTPInvalidParameter;
     }
     else if( pResponse->pBuffer == NULL )
     {
         LogError( ( "Parameter check failed: pResponse->pBuffer is NULL." ) );
-        returnStatus = HTTP_INVALID_PARAMETER;
+        returnStatus = HTTPInvalidParameter;
     }
     else if( pResponse->bufferLen == 0u )
     {
         LogError( ( "Parameter check failed: pResponse->bufferLen is 0: "
                     "Buffer len should be > 0." ) );
-        returnStatus = HTTP_INVALID_PARAMETER;
+        returnStatus = HTTPInvalidParameter;
     }
     else if( pField == NULL )
     {
         LogError( ( "Parameter check failed: Input header name is NULL." ) );
-        returnStatus = HTTP_INVALID_PARAMETER;
+        returnStatus = HTTPInvalidParameter;
     }
     else if( fieldLen == 0u )
     {
         LogError( ( "Parameter check failed: Input header name length is 0: "
                     "fieldLen should be > 0." ) );
-        returnStatus = HTTP_INVALID_PARAMETER;
+        returnStatus = HTTPInvalidParameter;
     }
     else if( pValueLoc == NULL )
     {
         LogError( ( "Parameter check failed: Output parameter for header value location is NULL." ) );
-        returnStatus = HTTP_INVALID_PARAMETER;
+        returnStatus = HTTPInvalidParameter;
     }
     else if( pValueLen == NULL )
     {
         LogError( ( "Parameter check failed: Output parameter for header value length is NULL." ) );
-        returnStatus = HTTP_INVALID_PARAMETER;
+        returnStatus = HTTPInvalidParameter;
     }
     else
     {
@@ -2362,8 +2362,8 @@ const char * HTTPClient_strerror( HTTPStatus_t status )
             str = "HTTPSuccess";
             break;
 
-        case HTTP_INVALID_PARAMETER:
-            str = "HTTP_INVALID_PARAMETER";
+        case HTTPInvalidParameter:
+            str = "HTTPInvalidParameter";
             break;
 
         case HTTP_NETWORK_ERROR:

--- a/source/include/core_http_client.h
+++ b/source/include/core_http_client.h
@@ -203,7 +203,7 @@ typedef enum HTTPStatus
      * Functions that may return this value:
      * - #HTTPClient_Send
      */
-    HTTP_NO_RESPONSE,
+    HTTPNoResponse,
 
     /**
      * @brief The application buffer was not large enough for the HTTP request
@@ -731,7 +731,7 @@ HTTPStatus_t HTTPClient_AddRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
  * - #HTTPInvalidParameter (If any provided parameters or their members are invalid.)
  * - #HTTPNetworkError (Errors in sending or receiving over the transport interface.)
  * - #HTTPPartialResponse (Part of an HTTP response was received in a partially filled response buffer.)
- * - #HTTP_NO_RESPONSE (No data was received from the transport interface.)
+ * - #HTTPNoResponse (No data was received from the transport interface.)
  * - #HTTP_INSUFFICIENT_MEMORY (The response received could not fit into the response buffer
  * or extra headers could not be sent in the request.)
  * - #HTTP_PARSER_INTERNAL_ERROR (Internal parsing error.)\n\n

--- a/source/include/core_http_client.h
+++ b/source/include/core_http_client.h
@@ -164,7 +164,7 @@ typedef enum HTTPStatus
      * - #HTTPClient_Send
      * - #HTTPClient_ReadHeader
      */
-    HTTP_SUCCESS,
+    HTTPSuccess,
 
     /**
      * @brief The HTTP Client library function input an invalid parameter.
@@ -520,13 +520,13 @@ typedef struct HTTPResponse
  * @param[in] pRequestHeaders Request header buffer information.
  * @param[in] pRequestInfo Initial request header configurations.
  * @return One of the following:
- * - #HTTP_SUCCESS (If successful)
+ * - #HTTPSuccess (If successful)
  * - #HTTP_INVALID_PARAMETER (If any provided parameters or their members are invalid.)
  * - #HTTP_INSUFFICIENT_MEMORY (If provided buffer size is not large enough to hold headers.)
  *
  * **Example**
  * @code{c}
- * HTTPStatus_t httpLibraryStatus = HTTP_SUCCESS;
+ * HTTPStatus_t httpLibraryStatus = HTTPSuccess;
  * // Declare an HTTPRequestHeaders_t and HTTPRequestInfo_t.
  * HTTPRequestHeaders_t requestHeaders = { 0 };
  * HTTPRequestInfo_t requestInfo = { 0 };
@@ -583,13 +583,13 @@ HTTPStatus_t HTTPClient_InitializeRequestHeaders( HTTPRequestHeaders_t * pReques
  * @param[in] valueLen The byte length of the header field value.
  *
  * @return One of the following:
- * - #HTTP_SUCCESS (If successful.)
+ * - #HTTPSuccess (If successful.)
  * - #HTTP_INVALID_PARAMETER (If any provided parameters or their members are invalid.)
  * - #HTTP_INSUFFICIENT_MEMORY (If application-provided buffer is not large enough to hold headers.)
  *
  * **Example**
  * @code{c}
- * HTTPStatus_t httpLibraryStatus = HTTP_SUCCESS;
+ * HTTPStatus_t httpLibraryStatus = HTTPSuccess;
  * // Assume that requestHeaders has already been initialized with
  * // HTTPClient_InitializeRequestHeaders().
  * HTTPRequestHeaders_t requestHeaders;
@@ -627,7 +627,7 @@ HTTPStatus_t HTTPClient_AddHeader( HTTPRequestHeaders_t * pRequestHeaders,
  *    Example request header line: `Range: bytes=0-1023\r\n` for requesting bytes in the range [0, 1023].<br>
  *    **Example**
  *    @code{c}
- *    HTTPStatus_t httpLibraryStatus = HTTP_SUCCESS;
+ *    HTTPStatus_t httpLibraryStatus = HTTPSuccess;
  *    // Assume that requestHeaders has already been initialized with
  *    // HTTPClient_InitializeRequestHeaders().
  *    HTTPRequestHeaders_t requestHeaders;
@@ -643,7 +643,7 @@ HTTPStatus_t HTTPClient_AddHeader( HTTPRequestHeaders_t * pRequestHeaders,
  *    (or bytes in the range [512, 1023] for a 1KB sized file).<br>
  *    **Example**
  *    @code{c}
- *    HTTPStatus_t httpLibraryStatus = HTTP_SUCCESS;
+ *    HTTPStatus_t httpLibraryStatus = HTTPSuccess;
  *    // Assume that requestHeaders has already been initialized with
  *    // HTTPClient_InitializeRequestHeaders().
  *    HTTPRequestHeaders_t requestHeaders;
@@ -660,7 +660,7 @@ HTTPStatus_t HTTPClient_AddHeader( HTTPRequestHeaders_t * pRequestHeaders,
  *    including byte 256 (or bytes in the range [256,1023] for a 1kB sized file).<br>
  *    **Example**
  *    @code{c}
- *    HTTPStatus_t httpLibraryStatus = HTTP_SUCCESS;
+ *    HTTPStatus_t httpLibraryStatus = HTTPSuccess;
  *    // Assume that requestHeaders has already been initialized with
  *    // HTTPClient_InitializeRequestHeaders().
  *    HTTPRequestHeaders_t requestHeaders;
@@ -677,7 +677,7 @@ HTTPStatus_t HTTPClient_AddHeader( HTTPRequestHeaders_t * pRequestHeaders,
  * should be passed.
  *
  * @return Returns the following status codes:
- * #HTTP_SUCCESS if successful.
+ * #HTTPSuccess if successful.
  * #HTTP_INVALID_PARAMETER, if input parameters are invalid, including when
  * the @p rangeStartOrlastNbytes and @p rangeEnd parameter combination is invalid.
  * #HTTP_INSUFFICIENT_MEMORY, if the passed #HTTPRequestHeaders_t.pBuffer
@@ -712,7 +712,7 @@ HTTPStatus_t HTTPClient_AddRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
  * - #HTTP_SECURITY_ALERT_INVALID_CHARACTER
  * - #HTTP_SECURITY_ALERT_INVALID_CONTENT_LENGTH
  *
- * The @p pResponse returned is valid only if this function returns HTTP_SUCCESS.
+ * The @p pResponse returned is valid only if this function returns HTTPSuccess.
  *
  * @param[in] pTransport Transport interface, see #TransportInterface_t for
  * more information.
@@ -727,7 +727,7 @@ HTTPStatus_t HTTPClient_AddRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
  * see @ref http_send_flags for more information.
  *
  * @return One of the following:
- * - #HTTP_SUCCESS (If successful.)
+ * - #HTTPSuccess (If successful.)
  * - #HTTP_INVALID_PARAMETER (If any provided parameters or their members are invalid.)
  * - #HTTP_NETWORK_ERROR (Errors in sending or receiving over the transport interface.)
  * - #HTTP_PARTIAL_RESPONSE (Part of an HTTP response was received in a partially filled response buffer.)
@@ -747,7 +747,7 @@ HTTPStatus_t HTTPClient_AddRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
  * **Example**
  * @code{c}
  * // Variables used in this example.
- * HTTPStatus_t httpLibraryStatus = HTTP_SUCCESS;
+ * HTTPStatus_t httpLibraryStatus = HTTPSuccess;
  * TransportInterface_t transportInterface = { 0 };
  * HTTPResponse_t = { 0 };
  * char requestBody[] = "This is an example request body.";
@@ -775,7 +775,7 @@ HTTPStatus_t HTTPClient_AddRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
  *                                      &response,
  *                                      0 );
  *
- * if( httpLibraryStatus == HTTP_SUCCESS )
+ * if( httpLibraryStatus == HTTPSuccess )
  * {
  *     if( response.status == 200 )
  *     {
@@ -811,7 +811,7 @@ HTTPStatus_t HTTPClient_Send( const TransportInterface_t * pTransport,
  * header value in bytes.
  *
  * @return One of the following:
- * - #HTTP_SUCCESS (If successful.)
+ * - #HTTPSuccess (If successful.)
  * - #HTTP_INVALID_PARAMETER (If any provided parameters or their members are invalid.)
  * - #HTTP_HEADER_NOT_FOUND (Header is not found in the passed response buffer.)
  * - #HTTP_INVALID_RESPONSE (Provided response is not a valid HTTP response for parsing.)
@@ -819,7 +819,7 @@ HTTPStatus_t HTTPClient_Send( const TransportInterface_t * pTransport,
  *
  * **Example**
  * @code{c}
- * HTTPStatus_t httpLibraryStatus = HTTP_SUCCESS;
+ * HTTPStatus_t httpLibraryStatus = HTTPSuccess;
  * // Assume that response is returned from a successful invocation of
  * // HTTPClient_Send().
  * HTTPResponse_t response;

--- a/source/include/core_http_client.h
+++ b/source/include/core_http_client.h
@@ -259,7 +259,7 @@ typedef enum HTTPStatus
      * Functions that may return this value:
      * - #HTTPClient_Send
      */
-    HTTP_SECURITY_ALERT_INVALID_STATUS_CODE,
+    HTTPSecurityAlertInvalidStatusCode,
 
     /**
      * @brief An invalid character was found in the HTTP response message.
@@ -708,7 +708,7 @@ HTTPStatus_t HTTPClient_AddRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
  * - #HTTPSecurityAlertExtraneousResponseData
  * - #HTTPSecurityAlertInvalidChunkHeader
  * - #HTTPSecurityAlertInvalidProtocolVersion
- * - #HTTP_SECURITY_ALERT_INVALID_STATUS_CODE
+ * - #HTTPSecurityAlertInvalidStatusCode
  * - #HTTP_SECURITY_ALERT_INVALID_CHARACTER
  * - #HTTP_SECURITY_ALERT_INVALID_CONTENT_LENGTH
  *
@@ -740,7 +740,7 @@ HTTPStatus_t HTTPClient_AddRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
  * - #HTTPSecurityAlertExtraneousResponseData
  * - #HTTPSecurityAlertInvalidChunkHeader
  * - #HTTPSecurityAlertInvalidProtocolVersion
- * - #HTTP_SECURITY_ALERT_INVALID_STATUS_CODE
+ * - #HTTPSecurityAlertInvalidStatusCode
  * - #HTTP_SECURITY_ALERT_INVALID_CHARACTER
  * - #HTTP_SECURITY_ALERT_INVALID_CONTENT_LENGTH
  *

--- a/source/include/core_http_client.h
+++ b/source/include/core_http_client.h
@@ -294,7 +294,7 @@ typedef enum HTTPStatus
      * Functions that may return this value:
      * - #HTTPClient_ReadHeader
      */
-    HTTP_HEADER_NOT_FOUND,
+    HTTPHeaderNotFound,
 
     /**
      * @brief The HTTP response, provided for parsing, is either corrupt or
@@ -813,7 +813,7 @@ HTTPStatus_t HTTPClient_Send( const TransportInterface_t * pTransport,
  * @return One of the following:
  * - #HTTPSuccess (If successful.)
  * - #HTTPInvalidParameter (If any provided parameters or their members are invalid.)
- * - #HTTP_HEADER_NOT_FOUND (Header is not found in the passed response buffer.)
+ * - #HTTPHeaderNotFound (Header is not found in the passed response buffer.)
  * - #HTTP_INVALID_RESPONSE (Provided response is not a valid HTTP response for parsing.)
  * - #HTTPParserInternalError(If an error in the response parser.)
  *

--- a/source/include/core_http_client.h
+++ b/source/include/core_http_client.h
@@ -241,7 +241,7 @@ typedef enum HTTPStatus
      * Functions that may return this value:
      * - #HTTPClient_Send
      */
-    HTTP_SECURITY_ALERT_INVALID_CHUNK_HEADER,
+    HTTPSecurityAlertInvalidChunkHeader,
 
     /**
      * @brief The server sent a response with an invalid character in the
@@ -706,7 +706,7 @@ HTTPStatus_t HTTPClient_AddRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
  * following errors are returned:
  * - #HTTPSecurityAlertResponseHeadersSizeLimitExceeded
  * - #HTTPSecurityAlertExtraneousResponseData
- * - #HTTP_SECURITY_ALERT_INVALID_CHUNK_HEADER
+ * - #HTTPSecurityAlertInvalidChunkHeader
  * - #HTTP_SECURITY_ALERT_INVALID_PROTOCOL_VERSION
  * - #HTTP_SECURITY_ALERT_INVALID_STATUS_CODE
  * - #HTTP_SECURITY_ALERT_INVALID_CHARACTER
@@ -738,7 +738,7 @@ HTTPStatus_t HTTPClient_AddRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
  * Security alerts are listed below, please see #HTTPStatus_t for more information:
  * - #HTTPSecurityAlertResponseHeadersSizeLimitExceeded
  * - #HTTPSecurityAlertExtraneousResponseData
- * - #HTTP_SECURITY_ALERT_INVALID_CHUNK_HEADER
+ * - #HTTPSecurityAlertInvalidChunkHeader
  * - #HTTP_SECURITY_ALERT_INVALID_PROTOCOL_VERSION
  * - #HTTP_SECURITY_ALERT_INVALID_STATUS_CODE
  * - #HTTP_SECURITY_ALERT_INVALID_CHARACTER

--- a/source/include/core_http_client.h
+++ b/source/include/core_http_client.h
@@ -267,7 +267,7 @@ typedef enum HTTPStatus
      * Functions that may return this value:
      * - #HTTPClient_Send
      */
-    HTTP_SECURITY_ALERT_INVALID_CHARACTER,
+    HTTPSecurityAlertInvalidCharacter,
 
     /**
      * @brief The response contains either an invalid character in the
@@ -709,7 +709,7 @@ HTTPStatus_t HTTPClient_AddRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
  * - #HTTPSecurityAlertInvalidChunkHeader
  * - #HTTPSecurityAlertInvalidProtocolVersion
  * - #HTTPSecurityAlertInvalidStatusCode
- * - #HTTP_SECURITY_ALERT_INVALID_CHARACTER
+ * - #HTTPSecurityAlertInvalidCharacter
  * - #HTTP_SECURITY_ALERT_INVALID_CONTENT_LENGTH
  *
  * The @p pResponse returned is valid only if this function returns HTTPSuccess.
@@ -741,7 +741,7 @@ HTTPStatus_t HTTPClient_AddRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
  * - #HTTPSecurityAlertInvalidChunkHeader
  * - #HTTPSecurityAlertInvalidProtocolVersion
  * - #HTTPSecurityAlertInvalidStatusCode
- * - #HTTP_SECURITY_ALERT_INVALID_CHARACTER
+ * - #HTTPSecurityAlertInvalidCharacter
  * - #HTTP_SECURITY_ALERT_INVALID_CONTENT_LENGTH
  *
  * **Example**

--- a/source/include/core_http_client.h
+++ b/source/include/core_http_client.h
@@ -250,7 +250,7 @@ typedef enum HTTPStatus
      * Functions that may return this value:
      * - #HTTPClient_Send
      */
-    HTTP_SECURITY_ALERT_INVALID_PROTOCOL_VERSION,
+    HTTPSecurityAlertInvalidProtocolVersion,
 
     /**
      * @brief The server sent a response with an invalid character in the
@@ -677,7 +677,7 @@ HTTPStatus_t HTTPClient_AddHeader( HTTPRequestHeaders_t * pRequestHeaders,
  * should be passed.
  *
  * @return Returns the following status codes:
- * #HTTPSuccess if successful.
+ * #HTTPSuccess, if successful.
  * #HTTPInvalidParameter, if input parameters are invalid, including when
  * the @p rangeStartOrlastNbytes and @p rangeEnd parameter combination is invalid.
  * #HTTPInsufficientMemory, if the passed #HTTPRequestHeaders_t.pBuffer
@@ -707,7 +707,7 @@ HTTPStatus_t HTTPClient_AddRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
  * - #HTTPSecurityAlertResponseHeadersSizeLimitExceeded
  * - #HTTPSecurityAlertExtraneousResponseData
  * - #HTTPSecurityAlertInvalidChunkHeader
- * - #HTTP_SECURITY_ALERT_INVALID_PROTOCOL_VERSION
+ * - #HTTPSecurityAlertInvalidProtocolVersion
  * - #HTTP_SECURITY_ALERT_INVALID_STATUS_CODE
  * - #HTTP_SECURITY_ALERT_INVALID_CHARACTER
  * - #HTTP_SECURITY_ALERT_INVALID_CONTENT_LENGTH
@@ -739,7 +739,7 @@ HTTPStatus_t HTTPClient_AddRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
  * - #HTTPSecurityAlertResponseHeadersSizeLimitExceeded
  * - #HTTPSecurityAlertExtraneousResponseData
  * - #HTTPSecurityAlertInvalidChunkHeader
- * - #HTTP_SECURITY_ALERT_INVALID_PROTOCOL_VERSION
+ * - #HTTPSecurityAlertInvalidProtocolVersion
  * - #HTTP_SECURITY_ALERT_INVALID_STATUS_CODE
  * - #HTTP_SECURITY_ALERT_INVALID_CHARACTER
  * - #HTTP_SECURITY_ALERT_INVALID_CONTENT_LENGTH

--- a/source/include/core_http_client.h
+++ b/source/include/core_http_client.h
@@ -233,7 +233,7 @@ typedef enum HTTPStatus
      * Functions that may return this value:
      * - #HTTPClient_Send
      */
-    HTTP_SECURITY_ALERT_EXTRANEOUS_RESPONSE_DATA,
+    HTTPSecurityAlertExtraneousResponseData,
 
     /**
      * @brief The server sent a chunk header containing an invalid character.
@@ -705,7 +705,7 @@ HTTPStatus_t HTTPClient_AddRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
  * The application should close the connection with the server if any of the
  * following errors are returned:
  * - #HTTPSecurityAlertResponseHeadersSizeLimitExceeded
- * - #HTTP_SECURITY_ALERT_EXTRANEOUS_RESPONSE_DATA
+ * - #HTTPSecurityAlertExtraneousResponseData
  * - #HTTP_SECURITY_ALERT_INVALID_CHUNK_HEADER
  * - #HTTP_SECURITY_ALERT_INVALID_PROTOCOL_VERSION
  * - #HTTP_SECURITY_ALERT_INVALID_STATUS_CODE
@@ -737,7 +737,7 @@ HTTPStatus_t HTTPClient_AddRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
  * - #HTTP_PARSER_INTERNAL_ERROR (Internal parsing error.)\n\n
  * Security alerts are listed below, please see #HTTPStatus_t for more information:
  * - #HTTPSecurityAlertResponseHeadersSizeLimitExceeded
- * - #HTTP_SECURITY_ALERT_EXTRANEOUS_RESPONSE_DATA
+ * - #HTTPSecurityAlertExtraneousResponseData
  * - #HTTP_SECURITY_ALERT_INVALID_CHUNK_HEADER
  * - #HTTP_SECURITY_ALERT_INVALID_PROTOCOL_VERSION
  * - #HTTP_SECURITY_ALERT_INVALID_STATUS_CODE

--- a/source/include/core_http_client.h
+++ b/source/include/core_http_client.h
@@ -176,7 +176,7 @@ typedef enum HTTPStatus
      * - #HTTPClient_Send
      * - #HTTPClient_ReadHeader
      */
-    HTTP_INVALID_PARAMETER,
+    HTTPInvalidParameter,
 
     /**
      * @brief A network error was returned from the transport interface.
@@ -521,7 +521,7 @@ typedef struct HTTPResponse
  * @param[in] pRequestInfo Initial request header configurations.
  * @return One of the following:
  * - #HTTPSuccess (If successful)
- * - #HTTP_INVALID_PARAMETER (If any provided parameters or their members are invalid.)
+ * - #HTTPInvalidParameter (If any provided parameters or their members are invalid.)
  * - #HTTP_INSUFFICIENT_MEMORY (If provided buffer size is not large enough to hold headers.)
  *
  * **Example**
@@ -584,7 +584,7 @@ HTTPStatus_t HTTPClient_InitializeRequestHeaders( HTTPRequestHeaders_t * pReques
  *
  * @return One of the following:
  * - #HTTPSuccess (If successful.)
- * - #HTTP_INVALID_PARAMETER (If any provided parameters or their members are invalid.)
+ * - #HTTPInvalidParameter (If any provided parameters or their members are invalid.)
  * - #HTTP_INSUFFICIENT_MEMORY (If application-provided buffer is not large enough to hold headers.)
  *
  * **Example**
@@ -678,7 +678,7 @@ HTTPStatus_t HTTPClient_AddHeader( HTTPRequestHeaders_t * pRequestHeaders,
  *
  * @return Returns the following status codes:
  * #HTTPSuccess if successful.
- * #HTTP_INVALID_PARAMETER, if input parameters are invalid, including when
+ * #HTTPInvalidParameter, if input parameters are invalid, including when
  * the @p rangeStartOrlastNbytes and @p rangeEnd parameter combination is invalid.
  * #HTTP_INSUFFICIENT_MEMORY, if the passed #HTTPRequestHeaders_t.pBuffer
  * contains insufficient remaining memory for storing the range request.
@@ -728,7 +728,7 @@ HTTPStatus_t HTTPClient_AddRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
  *
  * @return One of the following:
  * - #HTTPSuccess (If successful.)
- * - #HTTP_INVALID_PARAMETER (If any provided parameters or their members are invalid.)
+ * - #HTTPInvalidParameter (If any provided parameters or their members are invalid.)
  * - #HTTP_NETWORK_ERROR (Errors in sending or receiving over the transport interface.)
  * - #HTTP_PARTIAL_RESPONSE (Part of an HTTP response was received in a partially filled response buffer.)
  * - #HTTP_NO_RESPONSE (No data was received from the transport interface.)
@@ -812,7 +812,7 @@ HTTPStatus_t HTTPClient_Send( const TransportInterface_t * pTransport,
  *
  * @return One of the following:
  * - #HTTPSuccess (If successful.)
- * - #HTTP_INVALID_PARAMETER (If any provided parameters or their members are invalid.)
+ * - #HTTPInvalidParameter (If any provided parameters or their members are invalid.)
  * - #HTTP_HEADER_NOT_FOUND (Header is not found in the passed response buffer.)
  * - #HTTP_INVALID_RESPONSE (Provided response is not a valid HTTP response for parsing.)
  * - #HTTP_PARSER_INTERNAL_ERROR(If an error in the response parser.)

--- a/source/include/core_http_client.h
+++ b/source/include/core_http_client.h
@@ -192,7 +192,7 @@ typedef enum HTTPStatus
      * Functions that may return this value:
      * - #HTTPClient_Send
      */
-    HTTP_PARTIAL_RESPONSE,
+    HTTPPartialResponse,
 
     /**
      * @brief No HTTP response was received from the network.
@@ -730,7 +730,7 @@ HTTPStatus_t HTTPClient_AddRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
  * - #HTTPSuccess (If successful.)
  * - #HTTPInvalidParameter (If any provided parameters or their members are invalid.)
  * - #HTTPNetworkError (Errors in sending or receiving over the transport interface.)
- * - #HTTP_PARTIAL_RESPONSE (Part of an HTTP response was received in a partially filled response buffer.)
+ * - #HTTPPartialResponse (Part of an HTTP response was received in a partially filled response buffer.)
  * - #HTTP_NO_RESPONSE (No data was received from the transport interface.)
  * - #HTTP_INSUFFICIENT_MEMORY (The response received could not fit into the response buffer
  * or extra headers could not be sent in the request.)

--- a/source/include/core_http_client.h
+++ b/source/include/core_http_client.h
@@ -224,7 +224,7 @@ typedef enum HTTPStatus
      * Functions that may return this value:
      * - #HTTPClient_Send
      */
-    HTTP_SECURITY_ALERT_RESPONSE_HEADERS_SIZE_LIMIT_EXCEEDED,
+    HTTPSecurityAlertResponseHeadersSizeLimitExceeded,
 
     /**
      * @brief A response contained the "Connection: close" header, but there
@@ -704,7 +704,7 @@ HTTPStatus_t HTTPClient_AddRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
  *
  * The application should close the connection with the server if any of the
  * following errors are returned:
- * - #HTTP_SECURITY_ALERT_RESPONSE_HEADERS_SIZE_LIMIT_EXCEEDED
+ * - #HTTPSecurityAlertResponseHeadersSizeLimitExceeded
  * - #HTTP_SECURITY_ALERT_EXTRANEOUS_RESPONSE_DATA
  * - #HTTP_SECURITY_ALERT_INVALID_CHUNK_HEADER
  * - #HTTP_SECURITY_ALERT_INVALID_PROTOCOL_VERSION
@@ -736,7 +736,7 @@ HTTPStatus_t HTTPClient_AddRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
  * or extra headers could not be sent in the request.)
  * - #HTTP_PARSER_INTERNAL_ERROR (Internal parsing error.)\n\n
  * Security alerts are listed below, please see #HTTPStatus_t for more information:
- * - #HTTP_SECURITY_ALERT_RESPONSE_HEADERS_SIZE_LIMIT_EXCEEDED
+ * - #HTTPSecurityAlertResponseHeadersSizeLimitExceeded
  * - #HTTP_SECURITY_ALERT_EXTRANEOUS_RESPONSE_DATA
  * - #HTTP_SECURITY_ALERT_INVALID_CHUNK_HEADER
  * - #HTTP_SECURITY_ALERT_INVALID_PROTOCOL_VERSION

--- a/source/include/core_http_client.h
+++ b/source/include/core_http_client.h
@@ -277,7 +277,7 @@ typedef enum HTTPStatus
      * Functions that may return this value:
      * - #HTTPClient_Send
      */
-    HTTP_SECURITY_ALERT_INVALID_CONTENT_LENGTH,
+    HTTPSecurityAlertInvalidContentLength,
 
     /**
      * @brief An error occurred in the third-party parsing library.
@@ -710,7 +710,7 @@ HTTPStatus_t HTTPClient_AddRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
  * - #HTTPSecurityAlertInvalidProtocolVersion
  * - #HTTPSecurityAlertInvalidStatusCode
  * - #HTTPSecurityAlertInvalidCharacter
- * - #HTTP_SECURITY_ALERT_INVALID_CONTENT_LENGTH
+ * - #HTTPSecurityAlertInvalidContentLength
  *
  * The @p pResponse returned is valid only if this function returns HTTPSuccess.
  *
@@ -742,7 +742,7 @@ HTTPStatus_t HTTPClient_AddRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
  * - #HTTPSecurityAlertInvalidProtocolVersion
  * - #HTTPSecurityAlertInvalidStatusCode
  * - #HTTPSecurityAlertInvalidCharacter
- * - #HTTP_SECURITY_ALERT_INVALID_CONTENT_LENGTH
+ * - #HTTPSecurityAlertInvalidContentLength
  *
  * **Example**
  * @code{c}

--- a/source/include/core_http_client.h
+++ b/source/include/core_http_client.h
@@ -215,7 +215,7 @@ typedef enum HTTPStatus
      * - #HTTPClient_AddRangeHeader
      * - #HTTPClient_Send
      */
-    HTTP_INSUFFICIENT_MEMORY,
+    HTTPInsufficientMemory,
 
     /**
      * @brief The server sent more headers than the configured
@@ -522,7 +522,7 @@ typedef struct HTTPResponse
  * @return One of the following:
  * - #HTTPSuccess (If successful)
  * - #HTTPInvalidParameter (If any provided parameters or their members are invalid.)
- * - #HTTP_INSUFFICIENT_MEMORY (If provided buffer size is not large enough to hold headers.)
+ * - #HTTPInsufficientMemory (If provided buffer size is not large enough to hold headers.)
  *
  * **Example**
  * @code{c}
@@ -585,7 +585,7 @@ HTTPStatus_t HTTPClient_InitializeRequestHeaders( HTTPRequestHeaders_t * pReques
  * @return One of the following:
  * - #HTTPSuccess (If successful.)
  * - #HTTPInvalidParameter (If any provided parameters or their members are invalid.)
- * - #HTTP_INSUFFICIENT_MEMORY (If application-provided buffer is not large enough to hold headers.)
+ * - #HTTPInsufficientMemory (If application-provided buffer is not large enough to hold headers.)
  *
  * **Example**
  * @code{c}
@@ -680,7 +680,7 @@ HTTPStatus_t HTTPClient_AddHeader( HTTPRequestHeaders_t * pRequestHeaders,
  * #HTTPSuccess if successful.
  * #HTTPInvalidParameter, if input parameters are invalid, including when
  * the @p rangeStartOrlastNbytes and @p rangeEnd parameter combination is invalid.
- * #HTTP_INSUFFICIENT_MEMORY, if the passed #HTTPRequestHeaders_t.pBuffer
+ * #HTTPInsufficientMemory, if the passed #HTTPRequestHeaders_t.pBuffer
  * contains insufficient remaining memory for storing the range request.
  */
 /* @[declare_httpclient_addrangeheader] */
@@ -698,7 +698,7 @@ HTTPStatus_t HTTPClient_AddRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
  * then the Content-Length to be sent to the server is automatically written to
  * @p pRequestHeaders. The Content-Length will not be written when there is
  * no request body. If there is not enough room in the buffer to write the
- * Content-Length then #HTTP_INSUFFICIENT_MEMORY is returned. Please see
+ * Content-Length then #HTTPInsufficientMemory is returned. Please see
  * #HTTP_MAX_CONTENT_LENGTH_HEADER_LENGTH for the maximum Content-Length header
  * field and value that could be written to the buffer.
  *
@@ -732,7 +732,7 @@ HTTPStatus_t HTTPClient_AddRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
  * - #HTTPNetworkError (Errors in sending or receiving over the transport interface.)
  * - #HTTPPartialResponse (Part of an HTTP response was received in a partially filled response buffer.)
  * - #HTTPNoResponse (No data was received from the transport interface.)
- * - #HTTP_INSUFFICIENT_MEMORY (The response received could not fit into the response buffer
+ * - #HTTPInsufficientMemory (The response received could not fit into the response buffer
  * or extra headers could not be sent in the request.)
  * - #HTTP_PARSER_INTERNAL_ERROR (Internal parsing error.)\n\n
  * Security alerts are listed below, please see #HTTPStatus_t for more information:

--- a/source/include/core_http_client.h
+++ b/source/include/core_http_client.h
@@ -286,7 +286,7 @@ typedef enum HTTPStatus
      * - #HTTPClient_Send
      * - #HTTPClient_ReadHeader
      */
-    HTTP_PARSER_INTERNAL_ERROR,
+    HTTPParserInternalError,
 
     /**
      * @brief The requested header field was not found in the response buffer.
@@ -734,7 +734,7 @@ HTTPStatus_t HTTPClient_AddRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
  * - #HTTPNoResponse (No data was received from the transport interface.)
  * - #HTTPInsufficientMemory (The response received could not fit into the response buffer
  * or extra headers could not be sent in the request.)
- * - #HTTP_PARSER_INTERNAL_ERROR (Internal parsing error.)\n\n
+ * - #HTTPParserInternalError (Internal parsing error.)\n\n
  * Security alerts are listed below, please see #HTTPStatus_t for more information:
  * - #HTTPSecurityAlertResponseHeadersSizeLimitExceeded
  * - #HTTPSecurityAlertExtraneousResponseData
@@ -815,7 +815,7 @@ HTTPStatus_t HTTPClient_Send( const TransportInterface_t * pTransport,
  * - #HTTPInvalidParameter (If any provided parameters or their members are invalid.)
  * - #HTTP_HEADER_NOT_FOUND (Header is not found in the passed response buffer.)
  * - #HTTP_INVALID_RESPONSE (Provided response is not a valid HTTP response for parsing.)
- * - #HTTP_PARSER_INTERNAL_ERROR(If an error in the response parser.)
+ * - #HTTPParserInternalError(If an error in the response parser.)
  *
  * **Example**
  * @code{c}

--- a/source/include/core_http_client.h
+++ b/source/include/core_http_client.h
@@ -303,7 +303,7 @@ typedef enum HTTPStatus
      * Functions that may return this value:
      * - #HTTPClient_ReadHeader
      */
-    HTTP_INVALID_RESPONSE
+    HTTPInvalidResponse
 } HTTPStatus_t;
 
 /**
@@ -814,7 +814,7 @@ HTTPStatus_t HTTPClient_Send( const TransportInterface_t * pTransport,
  * - #HTTPSuccess (If successful.)
  * - #HTTPInvalidParameter (If any provided parameters or their members are invalid.)
  * - #HTTPHeaderNotFound (Header is not found in the passed response buffer.)
- * - #HTTP_INVALID_RESPONSE (Provided response is not a valid HTTP response for parsing.)
+ * - #HTTPInvalidResponse (Provided response is not a valid HTTP response for parsing.)
  * - #HTTPParserInternalError(If an error in the response parser.)
  *
  * **Example**

--- a/source/include/core_http_client.h
+++ b/source/include/core_http_client.h
@@ -184,7 +184,7 @@ typedef enum HTTPStatus
      * Functions that may return this value:
      * - #HTTPClient_Send
      */
-    HTTP_NETWORK_ERROR,
+    HTTPNetworkError,
 
     /**
      * @brief Part of the HTTP response was received from the network.
@@ -729,7 +729,7 @@ HTTPStatus_t HTTPClient_AddRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
  * @return One of the following:
  * - #HTTPSuccess (If successful.)
  * - #HTTPInvalidParameter (If any provided parameters or their members are invalid.)
- * - #HTTP_NETWORK_ERROR (Errors in sending or receiving over the transport interface.)
+ * - #HTTPNetworkError (Errors in sending or receiving over the transport interface.)
  * - #HTTP_PARTIAL_RESPONSE (Part of an HTTP response was received in a partially filled response buffer.)
  * - #HTTP_NO_RESPONSE (No data was received from the transport interface.)
  * - #HTTP_INSUFFICIENT_MEMORY (The response received could not fit into the response buffer

--- a/source/include/core_http_config_defaults.h
+++ b/source/include/core_http_config_defaults.h
@@ -40,7 +40,7 @@
  *
  * If the total size in bytes of the headers received from the server exceeds
  * this configuration, then the status code
- * #HTTP_SECURITY_ALERT_RESPONSE_HEADERS_SIZE_LIMIT_EXCEEDED is returned from
+ * #HTTPSecurityAlertResponseHeadersSizeLimitExceeded is returned from
  * #HTTPClient_Send.
  *
  * <b>Possible values:</b> Any positive 32 bit integer. <br>

--- a/test/unit-test/core_http_send_utest.c
+++ b/test/unit-test/core_http_send_utest.c
@@ -1505,7 +1505,7 @@ void test_HTTPClient_Send_parsing_errors( void )
                                     0,
                                     &response,
                                     0 );
-    TEST_ASSERT_EQUAL( HTTP_SECURITY_ALERT_RESPONSE_HEADERS_SIZE_LIMIT_EXCEEDED, returnStatus );
+    TEST_ASSERT_EQUAL( HTTPSecurityAlertResponseHeadersSizeLimitExceeded, returnStatus );
 
     httpParsingErrno = HPE_INVALID_CHUNK_SIZE;
     returnStatus = HTTPClient_Send( &transportInterface,

--- a/test/unit-test/core_http_send_utest.c
+++ b/test/unit-test/core_http_send_utest.c
@@ -1604,5 +1604,5 @@ void test_HTTPClient_Send_parsing_errors( void )
                                     0,
                                     &response,
                                     0 );
-    TEST_ASSERT_EQUAL( HTTP_PARSER_INTERNAL_ERROR, returnStatus );
+    TEST_ASSERT_EQUAL( HTTPParserInternalError, returnStatus );
 }

--- a/test/unit-test/core_http_send_utest.c
+++ b/test/unit-test/core_http_send_utest.c
@@ -1586,7 +1586,7 @@ void test_HTTPClient_Send_parsing_errors( void )
                                     0,
                                     &response,
                                     0 );
-    TEST_ASSERT_EQUAL( HTTP_SECURITY_ALERT_INVALID_CONTENT_LENGTH, returnStatus );
+    TEST_ASSERT_EQUAL( HTTPSecurityAlertInvalidContentLength, returnStatus );
 
     httpParsingErrno = HPE_UNEXPECTED_CONTENT_LENGTH;
     returnStatus = HTTPClient_Send( &transportInterface,
@@ -1595,7 +1595,7 @@ void test_HTTPClient_Send_parsing_errors( void )
                                     0,
                                     &response,
                                     0 );
-    TEST_ASSERT_EQUAL( HTTP_SECURITY_ALERT_INVALID_CONTENT_LENGTH, returnStatus );
+    TEST_ASSERT_EQUAL( HTTPSecurityAlertInvalidContentLength, returnStatus );
 
     httpParsingErrno = HPE_UNKNOWN;
     returnStatus = HTTPClient_Send( &transportInterface,

--- a/test/unit-test/core_http_send_utest.c
+++ b/test/unit-test/core_http_send_utest.c
@@ -1043,7 +1043,7 @@ void test_HTTPClient_Send_timeout_recv_immediate( void )
                                     0,
                                     &response,
                                     0 );
-    TEST_ASSERT_EQUAL( HTTP_NO_RESPONSE, returnStatus );
+    TEST_ASSERT_EQUAL( HTTPNoResponse, returnStatus );
 }
 
 /*-----------------------------------------------------------*/

--- a/test/unit-test/core_http_send_utest.c
+++ b/test/unit-test/core_http_send_utest.c
@@ -1550,7 +1550,7 @@ void test_HTTPClient_Send_parsing_errors( void )
                                     0,
                                     &response,
                                     0 );
-    TEST_ASSERT_EQUAL( HTTP_SECURITY_ALERT_INVALID_CHARACTER, returnStatus );
+    TEST_ASSERT_EQUAL( HTTPSecurityAlertInvalidCharacter, returnStatus );
 
     httpParsingErrno = HPE_INVALID_CONSTANT;
     returnStatus = HTTPClient_Send( &transportInterface,
@@ -1559,7 +1559,7 @@ void test_HTTPClient_Send_parsing_errors( void )
                                     0,
                                     &response,
                                     0 );
-    TEST_ASSERT_EQUAL( HTTP_SECURITY_ALERT_INVALID_CHARACTER, returnStatus );
+    TEST_ASSERT_EQUAL( HTTPSecurityAlertInvalidCharacter, returnStatus );
 
     httpParsingErrno = HPE_LF_EXPECTED;
     returnStatus = HTTPClient_Send( &transportInterface,
@@ -1568,7 +1568,7 @@ void test_HTTPClient_Send_parsing_errors( void )
                                     0,
                                     &response,
                                     0 );
-    TEST_ASSERT_EQUAL( HTTP_SECURITY_ALERT_INVALID_CHARACTER, returnStatus );
+    TEST_ASSERT_EQUAL( HTTPSecurityAlertInvalidCharacter, returnStatus );
 
     httpParsingErrno = HPE_INVALID_HEADER_TOKEN;
     returnStatus = HTTPClient_Send( &transportInterface,
@@ -1577,7 +1577,7 @@ void test_HTTPClient_Send_parsing_errors( void )
                                     0,
                                     &response,
                                     0 );
-    TEST_ASSERT_EQUAL( HTTP_SECURITY_ALERT_INVALID_CHARACTER, returnStatus );
+    TEST_ASSERT_EQUAL( HTTPSecurityAlertInvalidCharacter, returnStatus );
 
     httpParsingErrno = HPE_INVALID_CONTENT_LENGTH;
     returnStatus = HTTPClient_Send( &transportInterface,

--- a/test/unit-test/core_http_send_utest.c
+++ b/test/unit-test/core_http_send_utest.c
@@ -1273,7 +1273,7 @@ void test_HTTPClient_Send_null_transport_interface( void )
                                     &response,
                                     0 );
 
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, returnStatus );
+    TEST_ASSERT_EQUAL( HTTPInvalidParameter, returnStatus );
 }
 
 /*-----------------------------------------------------------*/
@@ -1291,7 +1291,7 @@ void test_HTTPClient_Send_null_transport_send( void )
                                     &response,
                                     0 );
 
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, returnStatus );
+    TEST_ASSERT_EQUAL( HTTPInvalidParameter, returnStatus );
 }
 
 /*-----------------------------------------------------------*/
@@ -1309,7 +1309,7 @@ void test_HTTPClient_Send_null_transport_recv( void )
                                     &response,
                                     0 );
 
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, returnStatus );
+    TEST_ASSERT_EQUAL( HTTPInvalidParameter, returnStatus );
 }
 
 /*-----------------------------------------------------------*/
@@ -1326,7 +1326,7 @@ void test_HTTPClient_Send_null_request_headers( void )
                                     &response,
                                     0 );
 
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, returnStatus );
+    TEST_ASSERT_EQUAL( HTTPInvalidParameter, returnStatus );
 }
 
 /*-----------------------------------------------------------*/
@@ -1344,7 +1344,7 @@ void test_HTTPClient_Send_null_request_header_buffer( void )
                                     &response,
                                     0 );
 
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, returnStatus );
+    TEST_ASSERT_EQUAL( HTTPInvalidParameter, returnStatus );
 }
 
 /*-----------------------------------------------------------*/
@@ -1362,7 +1362,7 @@ void test_HTTPClient_Send_request_headers_gt_buffer( void )
                                     &response,
                                     0 );
 
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, returnStatus );
+    TEST_ASSERT_EQUAL( HTTPInvalidParameter, returnStatus );
 }
 
 /*-----------------------------------------------------------*/
@@ -1380,7 +1380,7 @@ void test_HTTPClient_Send_null_response_buffer( void )
                                     &response,
                                     0 );
 
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, returnStatus );
+    TEST_ASSERT_EQUAL( HTTPInvalidParameter, returnStatus );
 }
 
 /*-----------------------------------------------------------*/
@@ -1401,7 +1401,7 @@ void test_HTTPClient_Send_request_body_buffer_length_gt_max( void )
                                     &response,
                                     0 );
 
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, returnStatus );
+    TEST_ASSERT_EQUAL( HTTPInvalidParameter, returnStatus );
 }
 
 /*-----------------------------------------------------------*/
@@ -1419,7 +1419,7 @@ void test_HTTPClient_Send_not_enough_request_headers( void )
                                     0,
                                     &response,
                                     0 );
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, returnStatus );
+    TEST_ASSERT_EQUAL( HTTPInvalidParameter, returnStatus );
 }
 
 /*-----------------------------------------------------------*/
@@ -1441,7 +1441,7 @@ void test_HTTPClient_Send_headers_length_gt_max( void )
                                     &response,
                                     0 );
 
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, returnStatus );
+    TEST_ASSERT_EQUAL( HTTPInvalidParameter, returnStatus );
 }
 
 /*-----------------------------------------------------------*/
@@ -1458,7 +1458,7 @@ void test_HTTPClient_Send_null_request_body_nonzero_body_length( void )
                                     1,
                                     &response,
                                     0 );
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, returnStatus );
+    TEST_ASSERT_EQUAL( HTTPInvalidParameter, returnStatus );
 }
 
 /*-----------------------------------------------------------*/

--- a/test/unit-test/core_http_send_utest.c
+++ b/test/unit-test/core_http_send_utest.c
@@ -1532,7 +1532,7 @@ void test_HTTPClient_Send_parsing_errors( void )
                                     0,
                                     &response,
                                     0 );
-    TEST_ASSERT_EQUAL( HTTP_SECURITY_ALERT_INVALID_PROTOCOL_VERSION, returnStatus );
+    TEST_ASSERT_EQUAL( HTTPSecurityAlertInvalidProtocolVersion, returnStatus );
 
     httpParsingErrno = HPE_INVALID_STATUS;
     returnStatus = HTTPClient_Send( &transportInterface,

--- a/test/unit-test/core_http_send_utest.c
+++ b/test/unit-test/core_http_send_utest.c
@@ -1523,7 +1523,7 @@ void test_HTTPClient_Send_parsing_errors( void )
                                     0,
                                     &response,
                                     0 );
-    TEST_ASSERT_EQUAL( HTTP_SECURITY_ALERT_EXTRANEOUS_RESPONSE_DATA, returnStatus );
+    TEST_ASSERT_EQUAL( HTTPSecurityAlertExtraneousResponseData, returnStatus );
 
     httpParsingErrno = HPE_INVALID_VERSION;
     returnStatus = HTTPClient_Send( &transportInterface,

--- a/test/unit-test/core_http_send_utest.c
+++ b/test/unit-test/core_http_send_utest.c
@@ -1514,7 +1514,7 @@ void test_HTTPClient_Send_parsing_errors( void )
                                     0,
                                     &response,
                                     0 );
-    TEST_ASSERT_EQUAL( HTTP_SECURITY_ALERT_INVALID_CHUNK_HEADER, returnStatus );
+    TEST_ASSERT_EQUAL( HTTPSecurityAlertInvalidChunkHeader, returnStatus );
 
     httpParsingErrno = HPE_CLOSED_CONNECTION;
     returnStatus = HTTPClient_Send( &transportInterface,

--- a/test/unit-test/core_http_send_utest.c
+++ b/test/unit-test/core_http_send_utest.c
@@ -1097,7 +1097,7 @@ void test_HTTPClient_Send_response_larger_than_buffer( void )
                                     0,
                                     &response,
                                     0 );
-    TEST_ASSERT_EQUAL( HTTP_INSUFFICIENT_MEMORY, returnStatus );
+    TEST_ASSERT_EQUAL( HTTPInsufficientMemory, returnStatus );
 }
 
 /*-----------------------------------------------------------*/
@@ -1482,7 +1482,7 @@ void test_HTTPClient_Send_Content_Length_Header_Doesnt_Fit( void )
                                     &response,
                                     0 );
 
-    TEST_ASSERT_EQUAL( HTTP_INSUFFICIENT_MEMORY, returnStatus );
+    TEST_ASSERT_EQUAL( HTTPInsufficientMemory, returnStatus );
 }
 
 /*-----------------------------------------------------------*/

--- a/test/unit-test/core_http_send_utest.c
+++ b/test/unit-test/core_http_send_utest.c
@@ -1135,7 +1135,7 @@ void test_HTTPClient_Send_network_error_request_headers( void )
                                     0U,
                                     &response,
                                     0U );
-    TEST_ASSERT_EQUAL( HTTP_NETWORK_ERROR, returnStatus );
+    TEST_ASSERT_EQUAL( HTTPNetworkError, returnStatus );
 }
 
 /*-----------------------------------------------------------*/
@@ -1160,7 +1160,7 @@ void test_HTTPClient_Send_network_error_request_body( void )
                                     &response,
                                     HTTP_SEND_DISABLE_CONTENT_LENGTH_FLAG );
 
-    TEST_ASSERT_EQUAL( HTTP_NETWORK_ERROR, returnStatus );
+    TEST_ASSERT_EQUAL( HTTPNetworkError, returnStatus );
 }
 
 /*-----------------------------------------------------------*/
@@ -1256,7 +1256,7 @@ void test_HTTPClient_Send_network_error_response( void )
                                     0,
                                     &response,
                                     0 );
-    TEST_ASSERT_EQUAL( HTTP_NETWORK_ERROR, returnStatus );
+    TEST_ASSERT_EQUAL( HTTPNetworkError, returnStatus );
 }
 
 /*-----------------------------------------------------------*/

--- a/test/unit-test/core_http_send_utest.c
+++ b/test/unit-test/core_http_send_utest.c
@@ -768,7 +768,7 @@ void setUp( void )
  * message is present in the response buffer on the first network read. */
 void test_HTTPClient_Send_HEAD_request_parse_whole_response( void )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
 
     http_parser_execute_Stub( http_parser_execute_whole_response );
 
@@ -778,7 +778,7 @@ void test_HTTPClient_Send_HEAD_request_parse_whole_response( void )
                                     0,
                                     &response,
                                     0 );
-    TEST_ASSERT_EQUAL( HTTP_SUCCESS, returnStatus );
+    TEST_ASSERT_EQUAL( HTTPSuccess, returnStatus );
     TEST_ASSERT_EQUAL( NULL, response.pBody );
     TEST_ASSERT_EQUAL( 0U, response.bodyLen );
     TEST_ASSERT_EQUAL( response.pBuffer + ( sizeof( HTTP_STATUS_LINE_OK ) - 1U ), response.pHeaders );
@@ -796,7 +796,7 @@ void test_HTTPClient_Send_HEAD_request_parse_whole_response( void )
  * message is present in the response buffer on the first network read. */
 void test_HTTPClient_Send_PUT_request_parse_whole_response( void )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
 
     http_parser_execute_Stub( http_parser_execute_whole_response );
 
@@ -816,7 +816,7 @@ void test_HTTPClient_Send_PUT_request_parse_whole_response( void )
                                     &response,
                                     0 );
 
-    TEST_ASSERT_EQUAL( HTTP_SUCCESS, returnStatus );
+    TEST_ASSERT_EQUAL( HTTPSuccess, returnStatus );
     TEST_ASSERT_EQUAL( response.pBuffer + ( sizeof( HTTP_STATUS_LINE_OK ) - 1 ), response.pHeaders );
     TEST_ASSERT_EQUAL( HTTP_TEST_RESPONSE_PUT_LENGTH - ( sizeof( HTTP_STATUS_LINE_OK ) - 1 ), response.headersLen );
     TEST_ASSERT_EQUAL( NULL, response.pBody );
@@ -834,7 +834,7 @@ void test_HTTPClient_Send_PUT_request_parse_whole_response( void )
  * message is present in the response buffer on the first network read. */
 void test_HTTPClient_Send_GET_request_parse_whole_response( void )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
 
     http_parser_execute_Stub( http_parser_execute_whole_response );
 
@@ -852,7 +852,7 @@ void test_HTTPClient_Send_GET_request_parse_whole_response( void )
                                     &response,
                                     0 );
 
-    TEST_ASSERT_EQUAL( HTTP_SUCCESS, returnStatus );
+    TEST_ASSERT_EQUAL( HTTPSuccess, returnStatus );
     TEST_ASSERT_EQUAL( response.pBuffer + ( sizeof( HTTP_STATUS_LINE_OK ) - 1 ), response.pHeaders );
     TEST_ASSERT_EQUAL( HTTP_TEST_RESPONSE_GET_HEADERS_LENGTH, response.headersLen );
     TEST_ASSERT_EQUAL( response.pHeaders + HTTP_TEST_RESPONSE_GET_HEADERS_LENGTH, response.pBody );
@@ -870,7 +870,7 @@ void test_HTTPClient_Send_GET_request_parse_whole_response( void )
  * response message is present in the response buffer on the first network read. */
 void test_HTTPClient_Send_no_response_headers( void )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
 
     http_parser_execute_Stub( http_parser_execute_whole_response );
 
@@ -884,7 +884,7 @@ void test_HTTPClient_Send_no_response_headers( void )
                                     0,
                                     &response,
                                     0 );
-    TEST_ASSERT_EQUAL( HTTP_SUCCESS, returnStatus );
+    TEST_ASSERT_EQUAL( HTTPSuccess, returnStatus );
     TEST_ASSERT_EQUAL( NULL, response.pBody );
     TEST_ASSERT_EQUAL( 0U, response.bodyLen );
     TEST_ASSERT_EQUAL( NULL, response.pHeaders );
@@ -903,7 +903,7 @@ void test_HTTPClient_Send_no_response_headers( void )
  * second read. */
 void test_HTTPClient_Send_parse_partial_header_field( void )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
 
     http_parser_execute_Stub( http_parser_execute_partial_header_field );
 
@@ -914,7 +914,7 @@ void test_HTTPClient_Send_parse_partial_header_field( void )
                                     0,
                                     &response,
                                     0 );
-    TEST_ASSERT_EQUAL( HTTP_SUCCESS, returnStatus );
+    TEST_ASSERT_EQUAL( HTTPSuccess, returnStatus );
     TEST_ASSERT_EQUAL( NULL, response.pBody );
     TEST_ASSERT_EQUAL( 0, response.bodyLen );
     TEST_ASSERT_EQUAL( response.pBuffer + ( sizeof( HTTP_STATUS_LINE_OK ) - 1U ), response.pHeaders );
@@ -933,7 +933,7 @@ void test_HTTPClient_Send_parse_partial_header_field( void )
  * second read. */
 void test_HTTPClient_Send_parse_partial_header_value( void )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
 
     http_parser_execute_Stub( http_parser_execute_partial_header_value );
 
@@ -944,7 +944,7 @@ void test_HTTPClient_Send_parse_partial_header_value( void )
                                     0,
                                     &response,
                                     0 );
-    TEST_ASSERT_EQUAL( HTTP_SUCCESS, returnStatus );
+    TEST_ASSERT_EQUAL( HTTPSuccess, returnStatus );
     TEST_ASSERT_EQUAL( NULL, response.pBody );
     TEST_ASSERT_EQUAL( 0, response.bodyLen );
     TEST_ASSERT_EQUAL( response.pBuffer + ( sizeof( HTTP_STATUS_LINE_OK ) - 1U ), response.pHeaders );
@@ -963,7 +963,7 @@ void test_HTTPClient_Send_parse_partial_header_value( void )
  * second read. */
 void test_HTTPClient_Send_parse_partial_body( void )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
 
     http_parser_execute_Stub( http_parser_execute_partial_body );
 
@@ -980,7 +980,7 @@ void test_HTTPClient_Send_parse_partial_body( void )
                                     0,
                                     &response,
                                     0 );
-    TEST_ASSERT_EQUAL( HTTP_SUCCESS, returnStatus );
+    TEST_ASSERT_EQUAL( HTTPSuccess, returnStatus );
     TEST_ASSERT_EQUAL( response.pBuffer + ( sizeof( HTTP_STATUS_LINE_OK ) - 1 ), response.pHeaders );
     TEST_ASSERT_EQUAL( HTTP_TEST_RESPONSE_GET_HEADERS_LENGTH, response.headersLen );
     TEST_ASSERT_EQUAL( response.pHeaders + HTTP_TEST_RESPONSE_GET_HEADERS_LENGTH, response.pBody );
@@ -997,7 +997,7 @@ void test_HTTPClient_Send_parse_partial_body( void )
 /* Test receiving a response where the body is of Transfer-Encoding chunked. */
 void test_HTTPClient_Send_parse_chunked_body( void )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
 
     http_parser_execute_Stub( http_parser_execute_chunked_body );
 
@@ -1015,7 +1015,7 @@ void test_HTTPClient_Send_parse_chunked_body( void )
                                     &response,
                                     0 );
 
-    TEST_ASSERT_EQUAL( HTTP_SUCCESS, returnStatus );
+    TEST_ASSERT_EQUAL( HTTPSuccess, returnStatus );
     TEST_ASSERT_EQUAL( response.pBuffer + ( sizeof( HTTP_STATUS_LINE_OK ) - 1 ), response.pHeaders );
     TEST_ASSERT_EQUAL( HTTP_TEST_RESPONSE_CHUNKED_HEADERS_LENGTH, response.headersLen );
     TEST_ASSERT_EQUAL( ( response.pHeaders + response.headersLen ), response.pBody );
@@ -1032,7 +1032,7 @@ void test_HTTPClient_Send_parse_chunked_body( void )
 /* Test a timeout is returned from the first network read. */
 void test_HTTPClient_Send_timeout_recv_immediate( void )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
 
     http_parser_execute_ExpectAnyArgsAndReturn( 0 );
 
@@ -1052,7 +1052,7 @@ void test_HTTPClient_Send_timeout_recv_immediate( void )
  * network read a partial response is received and parsed. */
 void test_HTTPClient_Send_timeout_partial_response( void )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
 
     http_parser_execute_Stub( http_parser_execute_partial_header_field );
     http_errno_description_IgnoreAndReturn( "Dummy unit test print." );
@@ -1075,7 +1075,7 @@ void test_HTTPClient_Send_timeout_partial_response( void )
  * the response is not complete. */
 void test_HTTPClient_Send_response_larger_than_buffer( void )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
 
     http_parser_execute_Stub( http_parser_execute_partial_body );
     http_errno_description_IgnoreAndReturn( "Dummy unit test print." );
@@ -1105,7 +1105,7 @@ void test_HTTPClient_Send_response_larger_than_buffer( void )
 /* Test sending a request with a NULL response configured. */
 void test_HTTPClient_Send_null_response( void )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
 
     memcpy( requestHeaders.pBuffer,
             HTTP_TEST_REQUEST_PUT_HEADERS,
@@ -1117,7 +1117,7 @@ void test_HTTPClient_Send_null_response( void )
                                     HTTP_TEST_REQUEST_PUT_BODY_LENGTH,
                                     NULL,
                                     0U );
-    TEST_ASSERT_EQUAL( HTTP_SUCCESS, returnStatus );
+    TEST_ASSERT_EQUAL( HTTPSuccess, returnStatus );
 }
 
 /*-----------------------------------------------------------*/
@@ -1125,7 +1125,7 @@ void test_HTTPClient_Send_null_response( void )
 /* Test a network error is returned when sending the request headers. */
 void test_HTTPClient_Send_network_error_request_headers( void )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
 
     sendErrorCall = 0U;
     transportInterface.send = transportSendNetworkError;
@@ -1143,7 +1143,7 @@ void test_HTTPClient_Send_network_error_request_headers( void )
 /* Test a network error is returned when sending the request body. */
 void test_HTTPClient_Send_network_error_request_body( void )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
 
     transportInterface.send = transportSendNetworkError;
 
@@ -1168,7 +1168,7 @@ void test_HTTPClient_Send_network_error_request_body( void )
 /* Test less bytes, of the request headers, are sent than expected. */
 void test_HTTPClient_Send_less_bytes_request_headers( void )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
 
     http_parser_execute_Stub( http_parser_execute_whole_response );
 
@@ -1189,7 +1189,7 @@ void test_HTTPClient_Send_less_bytes_request_headers( void )
                                     &response,
                                     0 );
 
-    TEST_ASSERT_EQUAL( HTTP_SUCCESS, returnStatus );
+    TEST_ASSERT_EQUAL( HTTPSuccess, returnStatus );
     TEST_ASSERT_EQUAL( response.pBuffer + ( sizeof( HTTP_STATUS_LINE_OK ) - 1 ), response.pHeaders );
     TEST_ASSERT_EQUAL( HTTP_TEST_RESPONSE_PUT_LENGTH - ( sizeof( HTTP_STATUS_LINE_OK ) - 1 ), response.headersLen );
     TEST_ASSERT_EQUAL( NULL, response.pBody );
@@ -1206,7 +1206,7 @@ void test_HTTPClient_Send_less_bytes_request_headers( void )
 /* Test less bytes, of the request body, are sent that expected. */
 void test_HTTPClient_Send_less_bytes_request_body( void )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
 
     http_parser_execute_Stub( http_parser_execute_whole_response );
 
@@ -1228,7 +1228,7 @@ void test_HTTPClient_Send_less_bytes_request_body( void )
                                     &response,
                                     HTTP_SEND_DISABLE_CONTENT_LENGTH_FLAG );
 
-    TEST_ASSERT_EQUAL( HTTP_SUCCESS, returnStatus );
+    TEST_ASSERT_EQUAL( HTTPSuccess, returnStatus );
     TEST_ASSERT_EQUAL( response.pBuffer + ( sizeof( HTTP_STATUS_LINE_OK ) - 1 ), response.pHeaders );
     TEST_ASSERT_EQUAL( HTTP_TEST_RESPONSE_PUT_LENGTH - ( sizeof( HTTP_STATUS_LINE_OK ) - 1 ), response.headersLen );
     TEST_ASSERT_EQUAL( NULL, response.pBody );
@@ -1245,7 +1245,7 @@ void test_HTTPClient_Send_less_bytes_request_body( void )
 /* Test when a network error is returned when receiving the response. */
 void test_HTTPClient_Send_network_error_response( void )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
 
     http_parser_init_Ignore();
 
@@ -1264,7 +1264,7 @@ void test_HTTPClient_Send_network_error_response( void )
 /* Test a NULL transport interface passed to the API. */
 void test_HTTPClient_Send_null_transport_interface( void )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
 
     returnStatus = HTTPClient_Send( NULL,
                                     &requestHeaders,
@@ -1281,7 +1281,7 @@ void test_HTTPClient_Send_null_transport_interface( void )
 /* Test a NULL transport send callback passed to the API. */
 void test_HTTPClient_Send_null_transport_send( void )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
 
     transportInterface.send = NULL;
     returnStatus = HTTPClient_Send( &transportInterface,
@@ -1299,7 +1299,7 @@ void test_HTTPClient_Send_null_transport_send( void )
 /* Test a NULL transport receive callback passed to the API. */
 void test_HTTPClient_Send_null_transport_recv( void )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
 
     transportInterface.recv = NULL;
     returnStatus = HTTPClient_Send( &transportInterface,
@@ -1317,7 +1317,7 @@ void test_HTTPClient_Send_null_transport_recv( void )
 /* Test a NULL request headers structure passed to the API. */
 void test_HTTPClient_Send_null_request_headers( void )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
 
     returnStatus = HTTPClient_Send( &transportInterface,
                                     NULL,
@@ -1334,7 +1334,7 @@ void test_HTTPClient_Send_null_request_headers( void )
 /* Test a null request headers buffer passed to the API. */
 void test_HTTPClient_Send_null_request_header_buffer( void )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
 
     requestHeaders.pBuffer = NULL;
     returnStatus = HTTPClient_Send( &transportInterface,
@@ -1352,7 +1352,7 @@ void test_HTTPClient_Send_null_request_header_buffer( void )
 /* Test when the length of request headers is greater than length of buffer. */
 void test_HTTPClient_Send_request_headers_gt_buffer( void )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
 
     requestHeaders.headersLen = requestHeaders.bufferLen + 1;
     returnStatus = HTTPClient_Send( &transportInterface,
@@ -1370,7 +1370,7 @@ void test_HTTPClient_Send_request_headers_gt_buffer( void )
 /* Test a NULL response buffer passed to the API. */
 void test_HTTPClient_Send_null_response_buffer( void )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
 
     response.pBuffer = NULL;
     returnStatus = HTTPClient_Send( &transportInterface,
@@ -1388,7 +1388,7 @@ void test_HTTPClient_Send_null_response_buffer( void )
 /* Test when reqBodyBufLen is greater than the max value of a 32-bit integer. */
 void test_HTTPClient_Send_request_body_buffer_length_gt_max( void )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
     size_t reqBodyBufLen = INT32_MAX;
 
     /* Increment separately to prevent an overflow warning. */
@@ -1410,7 +1410,7 @@ void test_HTTPClient_Send_request_body_buffer_length_gt_max( void )
  */
 void test_HTTPClient_Send_not_enough_request_headers( void )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
 
     requestHeaders.headersLen = HTTP_MINIMUM_REQUEST_LINE_LENGTH - 1;
     returnStatus = HTTPClient_Send( &transportInterface,
@@ -1427,7 +1427,7 @@ void test_HTTPClient_Send_not_enough_request_headers( void )
 /* Test when length of headers is greater than the max value of a 32-bit integer. */
 void test_HTTPClient_Send_headers_length_gt_max( void )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
 
     requestHeaders.headersLen = INT32_MAX;
     /* Increment separately to prevent an overflow warning. */
@@ -1450,7 +1450,7 @@ void test_HTTPClient_Send_headers_length_gt_max( void )
  */
 void test_HTTPClient_Send_null_request_body_nonzero_body_length( void )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
 
     returnStatus = HTTPClient_Send( &transportInterface,
                                     &requestHeaders,
@@ -1466,7 +1466,7 @@ void test_HTTPClient_Send_null_request_body_nonzero_body_length( void )
 /* Test when the Content-Length header cannot fit into the header buffer. */
 void test_HTTPClient_Send_Content_Length_Header_Doesnt_Fit( void )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
 
     requestHeaders.pBuffer = ( uint8_t * ) HTTP_TEST_REQUEST_PUT_HEADERS;
 
@@ -1491,7 +1491,7 @@ void test_HTTPClient_Send_Content_Length_Header_Doesnt_Fit( void )
  * errors. */
 void test_HTTPClient_Send_parsing_errors( void )
 {
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTPSuccess;
 
     http_parser_init_Ignore();
     http_parser_settings_init_Ignore();

--- a/test/unit-test/core_http_send_utest.c
+++ b/test/unit-test/core_http_send_utest.c
@@ -1066,7 +1066,7 @@ void test_HTTPClient_Send_timeout_partial_response( void )
                                     0,
                                     &response,
                                     0 );
-    TEST_ASSERT_EQUAL( HTTP_PARTIAL_RESPONSE, returnStatus );
+    TEST_ASSERT_EQUAL( HTTPPartialResponse, returnStatus );
 }
 
 /*-----------------------------------------------------------*/

--- a/test/unit-test/core_http_send_utest.c
+++ b/test/unit-test/core_http_send_utest.c
@@ -1541,7 +1541,7 @@ void test_HTTPClient_Send_parsing_errors( void )
                                     0,
                                     &response,
                                     0 );
-    TEST_ASSERT_EQUAL( HTTP_SECURITY_ALERT_INVALID_STATUS_CODE, returnStatus );
+    TEST_ASSERT_EQUAL( HTTPSecurityAlertInvalidStatusCode, returnStatus );
 
     httpParsingErrno = HPE_STRICT;
     returnStatus = HTTPClient_Send( &transportInterface,

--- a/test/unit-test/core_http_utest.c
+++ b/test/unit-test/core_http_utest.c
@@ -560,7 +560,7 @@ void test_Http_InitializeRequestHeaders_ReqInfo()
 }
 
 /**
- * @brief Test HTTP_INSUFFICIENT_MEMORY from having requestHeaders.bufferLen less than
+ * @brief Test HTTPInsufficientMemory from having requestHeaders.bufferLen less than
  * what is required to fit HTTP_TEST_REQUEST_LINE.
  */
 void test_Http_InitializeRequestHeaders_Insufficient_Memory()
@@ -577,7 +577,7 @@ void test_Http_InitializeRequestHeaders_Insufficient_Memory()
     requestHeaders.bufferLen = HTTP_TEST_REQUEST_LINE_LEN - 1;
 
     httpStatus = HTTPClient_InitializeRequestHeaders( &requestHeaders, &requestInfo );
-    TEST_ASSERT_EQUAL( HTTP_INSUFFICIENT_MEMORY, httpStatus );
+    TEST_ASSERT_EQUAL( HTTPInsufficientMemory, httpStatus );
     TEST_ASSERT_TRUE( strncmp( ( char * ) requestHeaders.pBuffer,
                                HTTP_TEST_REQUEST_LINE,
                                HTTP_TEST_REQUEST_LINE_LEN ) != 0 );
@@ -771,11 +771,11 @@ void test_Http_AddHeader_Extra_Header_Insufficient_Memory()
     TEST_ASSERT_EQUAL( expectedHeaders.dataLen, requestHeaders.headersLen );
     TEST_ASSERT_EQUAL_MEMORY( expectedHeaders.buffer,
                               requestHeaders.pBuffer, expectedHeaders.dataLen );
-    TEST_ASSERT_EQUAL( HTTP_INSUFFICIENT_MEMORY, httpStatus );
+    TEST_ASSERT_EQUAL( HTTPInsufficientMemory, httpStatus );
 }
 
 /**
- * @brief Test HTTP_INSUFFICIENT_MEMORY error from having buffer size less than
+ * @brief Test HTTPInsufficientMemory error from having buffer size less than
  * what is required to fit a single HTTP header.
  */
 void test_Http_AddHeader_Single_Header_Insufficient_Memory()
@@ -803,7 +803,7 @@ void test_Http_AddHeader_Single_Header_Insufficient_Memory()
                                        HTTP_TEST_HEADER_FIELD_LEN,
                                        HTTP_TEST_HEADER_VALUE,
                                        HTTP_TEST_HEADER_VALUE_LEN );
-    TEST_ASSERT_EQUAL( HTTP_INSUFFICIENT_MEMORY, httpStatus );
+    TEST_ASSERT_EQUAL( HTTPInsufficientMemory, httpStatus );
 }
 
 /* ============== Testing HTTPClient_AddRangeHeader ================== */
@@ -835,7 +835,7 @@ void test_Http_AddRangeHeader_Invalid_Params( void )
     retCode = HTTPClient_AddRangeHeader( &testHeaders,
                                          0 /* rangeStart */,
                                          10 /* rangeEnd */ );
-    TEST_ASSERT_EQUAL( HTTP_INSUFFICIENT_MEMORY, retCode );
+    TEST_ASSERT_EQUAL( HTTPInsufficientMemory, retCode );
 
     /* Length of headers > length of buffer.*/
     tearDown();
@@ -914,7 +914,7 @@ void test_Http_AddRangeHeader_Insufficient_Memory( void )
     retCode = HTTPClient_AddRangeHeader( &testHeaders,
                                          testRangeStart,
                                          testRangeEnd );
-    TEST_ASSERT_EQUAL( HTTP_INSUFFICIENT_MEMORY, retCode );
+    TEST_ASSERT_EQUAL( HTTPInsufficientMemory, retCode );
     /* Verify the headers input parameter is unaltered. */
     TEST_ASSERT_EQUAL( preHeadersLen, testHeaders.headersLen );
     TEST_ASSERT_EQUAL( expectedHeaders.dataLen - 1, testHeaders.bufferLen );
@@ -1410,9 +1410,9 @@ void test_HTTPClient_strerror( void )
     str = HTTPClient_strerror( status );
     TEST_ASSERT_EQUAL_STRING( "HTTPNoResponse", str );
 
-    status = HTTP_INSUFFICIENT_MEMORY;
+    status = HTTPInsufficientMemory;
     str = HTTPClient_strerror( status );
-    TEST_ASSERT_EQUAL_STRING( "HTTP_INSUFFICIENT_MEMORY", str );
+    TEST_ASSERT_EQUAL_STRING( "HTTPInsufficientMemory", str );
 
     status = HTTP_SECURITY_ALERT_RESPONSE_HEADERS_SIZE_LIMIT_EXCEEDED;
     str = HTTPClient_strerror( status );

--- a/test/unit-test/core_http_utest.c
+++ b/test/unit-test/core_http_utest.c
@@ -151,7 +151,7 @@ static const char * pTestResponse = "HTTP/1.1 200 OK\r\n"
 #define HEADER_NOT_IN_BUFFER_LEN     ( sizeof( HEADER_NOT_IN_BUFFER ) - 1 )
 
 /* File-scoped Global variables */
-static HTTPStatus_t retCode = HTTP_SUCCESS;
+static HTTPStatus_t retCode = HTTPSuccess;
 static uint8_t testBuffer[ HTTP_TEST_BUFFER_SIZE ] = { 0 };
 static HTTPRequestHeaders_t testHeaders = { 0 };
 static _headers_t expectedHeaders = { 0 };
@@ -350,7 +350,7 @@ void setUp()
 /* Called after each test method. */
 void tearDown()
 {
-    retCode = HTTP_SUCCESS;
+    retCode = HTTPSuccess;
     memset( &testHeaders, 0, sizeof( testHeaders ) );
     memset( testBuffer, 0, sizeof( testBuffer ) );
     memset( &expectedHeaders, 0, sizeof( expectedHeaders ) );
@@ -420,7 +420,7 @@ static void setupBuffer( HTTPRequestHeaders_t * pRequestHeaders )
  */
 void test_Http_InitializeRequestHeaders_Happy_Path()
 {
-    HTTPStatus_t httpStatus = HTTP_SUCCESS;
+    HTTPStatus_t httpStatus = HTTPSuccess;
     HTTPRequestHeaders_t requestHeaders = { 0 };
     HTTPRequestInfo_t requestInfo = { 0 };
     int numBytes = 0;
@@ -441,7 +441,7 @@ void test_Http_InitializeRequestHeaders_Happy_Path()
     TEST_ASSERT_LESS_THAN( sizeof( expectedHeaders.buffer ), ( size_t ) numBytes );
 
     httpStatus = HTTPClient_InitializeRequestHeaders( &requestHeaders, &requestInfo );
-    TEST_ASSERT_EQUAL( HTTP_SUCCESS, httpStatus );
+    TEST_ASSERT_EQUAL( HTTPSuccess, httpStatus );
     TEST_ASSERT_EQUAL( expectedHeaders.dataLen, requestHeaders.headersLen );
     TEST_ASSERT_EQUAL_MEMORY( expectedHeaders.buffer, requestHeaders.pBuffer,
                               expectedHeaders.dataLen );
@@ -452,7 +452,7 @@ void test_Http_InitializeRequestHeaders_Happy_Path()
  */
 void test_Http_InitializeRequestHeaders_Invalid_Params()
 {
-    HTTPStatus_t httpStatus = HTTP_SUCCESS;
+    HTTPStatus_t httpStatus = HTTPSuccess;
     HTTPRequestHeaders_t requestHeaders = { 0 };
     HTTPRequestInfo_t requestInfo = { 0 };
 
@@ -497,7 +497,7 @@ void test_Http_InitializeRequestHeaders_Invalid_Params()
  */
 void test_Http_InitializeRequestHeaders_ReqInfo()
 {
-    HTTPStatus_t httpStatus = HTTP_SUCCESS;
+    HTTPStatus_t httpStatus = HTTPSuccess;
     HTTPRequestHeaders_t requestHeaders = { 0 };
     HTTPRequestInfo_t requestInfo = { 0 };
     int numBytes = 0;
@@ -530,7 +530,7 @@ void test_Http_InitializeRequestHeaders_ReqInfo()
     requestHeaders.pBuffer = testBuffer;
     requestHeaders.bufferLen = expectedHeaders.dataLen;
     httpStatus = HTTPClient_InitializeRequestHeaders( &requestHeaders, &requestInfo );
-    TEST_ASSERT_EQUAL( HTTP_SUCCESS, httpStatus );
+    TEST_ASSERT_EQUAL( HTTPSuccess, httpStatus );
     TEST_ASSERT_EQUAL( expectedHeaders.dataLen, requestHeaders.headersLen );
     TEST_ASSERT_EQUAL_MEMORY( expectedHeaders.buffer, requestHeaders.pBuffer,
                               expectedHeaders.dataLen );
@@ -553,7 +553,7 @@ void test_Http_InitializeRequestHeaders_ReqInfo()
     requestHeaders.pBuffer = testBuffer;
     requestHeaders.bufferLen = expectedHeaders.dataLen;
     httpStatus = HTTPClient_InitializeRequestHeaders( &requestHeaders, &requestInfo );
-    TEST_ASSERT_EQUAL( HTTP_SUCCESS, httpStatus );
+    TEST_ASSERT_EQUAL( HTTPSuccess, httpStatus );
     TEST_ASSERT_EQUAL( expectedHeaders.dataLen, requestHeaders.headersLen );
     TEST_ASSERT_EQUAL_MEMORY( expectedHeaders.buffer, requestHeaders.pBuffer,
                               expectedHeaders.dataLen );
@@ -565,7 +565,7 @@ void test_Http_InitializeRequestHeaders_ReqInfo()
  */
 void test_Http_InitializeRequestHeaders_Insufficient_Memory()
 {
-    HTTPStatus_t httpStatus = HTTP_SUCCESS;
+    HTTPStatus_t httpStatus = HTTPSuccess;
     HTTPRequestHeaders_t requestHeaders = { 0 };
     HTTPRequestInfo_t requestInfo = { 0 };
 
@@ -591,7 +591,7 @@ void test_Http_InitializeRequestHeaders_Insufficient_Memory()
  */
 void test_Http_AddHeader_Happy_Path()
 {
-    HTTPStatus_t httpStatus = HTTP_SUCCESS;
+    HTTPStatus_t httpStatus = HTTPSuccess;
     HTTPRequestHeaders_t requestHeaders = { 0 };
     int numBytes = 0;
 
@@ -625,7 +625,7 @@ void test_Http_AddHeader_Happy_Path()
     TEST_ASSERT_EQUAL( expectedHeaders.dataLen, requestHeaders.headersLen );
     TEST_ASSERT_EQUAL_MEMORY( expectedHeaders.buffer,
                               requestHeaders.pBuffer, expectedHeaders.dataLen );
-    TEST_ASSERT_EQUAL( HTTP_SUCCESS, httpStatus );
+    TEST_ASSERT_EQUAL( HTTPSuccess, httpStatus );
 }
 
 /**
@@ -633,7 +633,7 @@ void test_Http_AddHeader_Happy_Path()
  */
 void test_Http_AddHeader_Invalid_Params()
 {
-    HTTPStatus_t httpStatus = HTTP_SUCCESS;
+    HTTPStatus_t httpStatus = HTTPSuccess;
     HTTPRequestHeaders_t requestHeaders = { 0 };
 
     /* Test a NULL request headers interface. */
@@ -688,7 +688,7 @@ void test_Http_AddHeader_Invalid_Params()
  */
 void test_Http_AddHeader_Extra_Header_Sufficient_Memory()
 {
-    HTTPStatus_t httpStatus = HTTP_SUCCESS;
+    HTTPStatus_t httpStatus = HTTPSuccess;
     HTTPRequestHeaders_t requestHeaders = { 0 };
     int numBytes = 0;
 
@@ -725,7 +725,7 @@ void test_Http_AddHeader_Extra_Header_Sufficient_Memory()
     TEST_ASSERT_EQUAL( expectedHeaders.dataLen, requestHeaders.headersLen );
     TEST_ASSERT_EQUAL_MEMORY( expectedHeaders.buffer,
                               requestHeaders.pBuffer, expectedHeaders.dataLen );
-    TEST_ASSERT_EQUAL( HTTP_SUCCESS, httpStatus );
+    TEST_ASSERT_EQUAL( HTTPSuccess, httpStatus );
 }
 
 /**
@@ -733,7 +733,7 @@ void test_Http_AddHeader_Extra_Header_Sufficient_Memory()
  */
 void test_Http_AddHeader_Extra_Header_Insufficient_Memory()
 {
-    HTTPStatus_t httpStatus = HTTP_SUCCESS;
+    HTTPStatus_t httpStatus = HTTPSuccess;
     HTTPRequestHeaders_t requestHeaders = { 0 };
     int numBytes = 0;
 
@@ -780,7 +780,7 @@ void test_Http_AddHeader_Extra_Header_Insufficient_Memory()
  */
 void test_Http_AddHeader_Single_Header_Insufficient_Memory()
 {
-    HTTPStatus_t httpStatus = HTTP_SUCCESS;
+    HTTPStatus_t httpStatus = HTTPSuccess;
     HTTPRequestHeaders_t requestHeaders = { 0 };
     int numBytes = 0;
 
@@ -944,7 +944,7 @@ void test_Http_AddRangeHeader_Without_Trailing_Terminator( void )
     retCode = HTTPClient_AddRangeHeader( &testHeaders,
                                          testRangeStart,
                                          testRangeEnd );
-    TEST_ASSERT_EQUAL( HTTP_SUCCESS, retCode );
+    TEST_ASSERT_EQUAL( HTTPSuccess, retCode );
     /* Verify the the Range Request header data. */
     TEST_ASSERT_EQUAL( expectedHeaders.dataLen, testHeaders.headersLen );
     TEST_ASSERT_EQUAL_MEMORY( expectedHeaders.buffer,
@@ -974,7 +974,7 @@ void test_Http_AddRangeHeader_RangeType_File_SubRange( void )
     retCode = HTTPClient_AddRangeHeader( &testHeaders,
                                          testRangeStart,
                                          testRangeEnd );
-    TEST_ASSERT_EQUAL( HTTP_SUCCESS, retCode );
+    TEST_ASSERT_EQUAL( HTTPSuccess, retCode );
     /* Verify the the Range Request header data. */
     TEST_ASSERT_EQUAL( expectedHeaders.dataLen, testHeaders.headersLen );
     TEST_ASSERT_EQUAL_MEMORY( expectedHeaders.buffer,
@@ -996,7 +996,7 @@ void test_Http_AddRangeHeader_RangeType_File_SubRange( void )
     retCode = HTTPClient_AddRangeHeader( &testHeaders,
                                          testRangeStart,
                                          testRangeEnd );
-    TEST_ASSERT_EQUAL( HTTP_SUCCESS, retCode );
+    TEST_ASSERT_EQUAL( HTTPSuccess, retCode );
     /* Verify the the Range Request header data. */
     TEST_ASSERT_EQUAL( expectedHeaders.dataLen, testHeaders.headersLen );
     TEST_ASSERT_EQUAL_MEMORY( expectedHeaders.buffer,
@@ -1023,7 +1023,7 @@ void test_Http_AddRangeHeader_RangeType_Entire_File( void )
     retCode = HTTPClient_AddRangeHeader( &testHeaders,
                                          testRangeStart,
                                          testRangeEnd );
-    TEST_ASSERT_EQUAL( HTTP_SUCCESS, retCode );
+    TEST_ASSERT_EQUAL( HTTPSuccess, retCode );
     /* Verify the the Range Request header data. */
     TEST_ASSERT_EQUAL( expectedHeaders.dataLen, testHeaders.headersLen );
     TEST_ASSERT_EQUAL_MEMORY( expectedHeaders.buffer,
@@ -1053,7 +1053,7 @@ void test_Http_AddRangeHeader_RangeType_All_Bytes_From_RangeStart( void )
     retCode = HTTPClient_AddRangeHeader( &testHeaders,
                                          testRangeStart,
                                          testRangeEnd );
-    TEST_ASSERT_EQUAL( HTTP_SUCCESS, retCode );
+    TEST_ASSERT_EQUAL( HTTPSuccess, retCode );
     /* Verify the the Range Request header data. */
     TEST_ASSERT_EQUAL( expectedHeaders.dataLen, testHeaders.headersLen );
     TEST_ASSERT_EQUAL_MEMORY( expectedHeaders.buffer,
@@ -1081,7 +1081,7 @@ void test_Http_AddRangeHeader_RangeType_LastNBytes( void )
     retCode = HTTPClient_AddRangeHeader( &testHeaders,
                                          testRangeStart,
                                          testRangeEnd );
-    TEST_ASSERT_EQUAL( HTTP_SUCCESS, retCode );
+    TEST_ASSERT_EQUAL( HTTPSuccess, retCode );
     /* Verify the the Range Request header data. */
     TEST_ASSERT_EQUAL( expectedHeaders.dataLen, testHeaders.headersLen );
     TEST_ASSERT_EQUAL_MEMORY( expectedHeaders.buffer,
@@ -1109,7 +1109,7 @@ void test_Http_AddRangeHeader_With_Max_INT32_Range_Values( void )
     retCode = HTTPClient_AddRangeHeader( &testHeaders,
                                          testRangeStart,
                                          testRangeEnd );
-    TEST_ASSERT_EQUAL( HTTP_SUCCESS, retCode );
+    TEST_ASSERT_EQUAL( HTTPSuccess, retCode );
     /* Verify the the Range Request header data. */
     TEST_ASSERT_EQUAL( expectedHeaders.dataLen, testHeaders.headersLen );
     TEST_ASSERT_EQUAL_MEMORY( expectedHeaders.buffer,
@@ -1377,7 +1377,7 @@ void test_Http_ReadHeader_Happy_Path()
                                      HEADER_IN_BUFFER_LEN,
                                      &pValueLoc,
                                      &valueLen );
-    TEST_ASSERT_EQUAL( HTTP_SUCCESS, retCode );
+    TEST_ASSERT_EQUAL( HTTPSuccess, retCode );
     TEST_ASSERT_EQUAL( &pTestResponse[ headerValInRespLoc ], pValueLoc );
     TEST_ASSERT_EQUAL( headerValInRespLen, valueLen );
 }
@@ -1390,9 +1390,9 @@ void test_HTTPClient_strerror( void )
     HTTPStatus_t status;
     const char * str = NULL;
 
-    status = HTTP_SUCCESS;
+    status = HTTPSuccess;
     str = HTTPClient_strerror( status );
-    TEST_ASSERT_EQUAL_STRING( "HTTP_SUCCESS", str );
+    TEST_ASSERT_EQUAL_STRING( "HTTPSuccess", str );
 
     status = HTTP_INVALID_PARAMETER;
     str = HTTPClient_strerror( status );

--- a/test/unit-test/core_http_utest.c
+++ b/test/unit-test/core_http_utest.c
@@ -1217,7 +1217,7 @@ void test_Http_ReadHeader_Header_Not_In_Response( void )
                                      HEADER_NOT_IN_BUFFER_LEN,
                                      &pValueLoc,
                                      &valueLen );
-    TEST_ASSERT_EQUAL( HTTP_HEADER_NOT_FOUND, retCode );
+    TEST_ASSERT_EQUAL( HTTPHeaderNotFound, retCode );
 
     /* Repeat the test above but with fieldLenToReturn == HEADER_NOT_IN_BUFFER_LEN.
      * Doing this allows us to take the branch where the actual contents
@@ -1250,7 +1250,7 @@ void test_Http_ReadHeader_Header_Not_In_Response( void )
                                      HEADER_NOT_IN_BUFFER_LEN,
                                      &pValueLoc,
                                      &valueLen );
-    TEST_ASSERT_EQUAL( HTTP_HEADER_NOT_FOUND, retCode );
+    TEST_ASSERT_EQUAL( HTTPHeaderNotFound, retCode );
 }
 
 /**
@@ -1446,9 +1446,9 @@ void test_HTTPClient_strerror( void )
     str = HTTPClient_strerror( status );
     TEST_ASSERT_EQUAL_STRING( "HTTPParserInternalError", str );
 
-    status = HTTP_HEADER_NOT_FOUND;
+    status = HTTPHeaderNotFound;
     str = HTTPClient_strerror( status );
-    TEST_ASSERT_EQUAL_STRING( "HTTP_HEADER_NOT_FOUND", str );
+    TEST_ASSERT_EQUAL_STRING( "HTTPHeaderNotFound", str );
 
     status = HTTP_INVALID_RESPONSE;
     str = HTTPClient_strerror( status );

--- a/test/unit-test/core_http_utest.c
+++ b/test/unit-test/core_http_utest.c
@@ -1402,9 +1402,9 @@ void test_HTTPClient_strerror( void )
     str = HTTPClient_strerror( status );
     TEST_ASSERT_EQUAL_STRING( "HTTPNetworkError", str );
 
-    status = HTTP_PARTIAL_RESPONSE;
+    status = HTTPPartialResponse;
     str = HTTPClient_strerror( status );
-    TEST_ASSERT_EQUAL_STRING( "HTTP_PARTIAL_RESPONSE", str );
+    TEST_ASSERT_EQUAL_STRING( "HTTPPartialResponse", str );
 
     status = HTTP_NO_RESPONSE;
     str = HTTPClient_strerror( status );

--- a/test/unit-test/core_http_utest.c
+++ b/test/unit-test/core_http_utest.c
@@ -1406,9 +1406,9 @@ void test_HTTPClient_strerror( void )
     str = HTTPClient_strerror( status );
     TEST_ASSERT_EQUAL_STRING( "HTTPPartialResponse", str );
 
-    status = HTTP_NO_RESPONSE;
+    status = HTTPNoResponse;
     str = HTTPClient_strerror( status );
-    TEST_ASSERT_EQUAL_STRING( "HTTP_NO_RESPONSE", str );
+    TEST_ASSERT_EQUAL_STRING( "HTTPNoResponse", str );
 
     status = HTTP_INSUFFICIENT_MEMORY;
     str = HTTPClient_strerror( status );

--- a/test/unit-test/core_http_utest.c
+++ b/test/unit-test/core_http_utest.c
@@ -1418,9 +1418,9 @@ void test_HTTPClient_strerror( void )
     str = HTTPClient_strerror( status );
     TEST_ASSERT_EQUAL_STRING( "HTTPSecurityAlertResponseHeadersSizeLimitExceeded", str );
 
-    status = HTTP_SECURITY_ALERT_EXTRANEOUS_RESPONSE_DATA;
+    status = HTTPSecurityAlertExtraneousResponseData;
     str = HTTPClient_strerror( status );
-    TEST_ASSERT_EQUAL_STRING( "HTTP_SECURITY_ALERT_EXTRANEOUS_RESPONSE_DATA", str );
+    TEST_ASSERT_EQUAL_STRING( "HTTPSecurityAlertExtraneousResponseData", str );
 
     status = HTTP_SECURITY_ALERT_INVALID_CHUNK_HEADER;
     str = HTTPClient_strerror( status );

--- a/test/unit-test/core_http_utest.c
+++ b/test/unit-test/core_http_utest.c
@@ -1422,9 +1422,9 @@ void test_HTTPClient_strerror( void )
     str = HTTPClient_strerror( status );
     TEST_ASSERT_EQUAL_STRING( "HTTPSecurityAlertExtraneousResponseData", str );
 
-    status = HTTP_SECURITY_ALERT_INVALID_CHUNK_HEADER;
+    status = HTTPSecurityAlertInvalidChunkHeader;
     str = HTTPClient_strerror( status );
-    TEST_ASSERT_EQUAL_STRING( "HTTP_SECURITY_ALERT_INVALID_CHUNK_HEADER", str );
+    TEST_ASSERT_EQUAL_STRING( "HTTPSecurityAlertInvalidChunkHeader", str );
 
     status = HTTP_SECURITY_ALERT_INVALID_PROTOCOL_VERSION;
     str = HTTPClient_strerror( status );

--- a/test/unit-test/core_http_utest.c
+++ b/test/unit-test/core_http_utest.c
@@ -1438,9 +1438,9 @@ void test_HTTPClient_strerror( void )
     str = HTTPClient_strerror( status );
     TEST_ASSERT_EQUAL_STRING( "HTTPSecurityAlertInvalidCharacter", str );
 
-    status = HTTP_SECURITY_ALERT_INVALID_CONTENT_LENGTH;
+    status = HTTPSecurityAlertInvalidContentLength;
     str = HTTPClient_strerror( status );
-    TEST_ASSERT_EQUAL_STRING( "HTTP_SECURITY_ALERT_INVALID_CONTENT_LENGTH", str );
+    TEST_ASSERT_EQUAL_STRING( "HTTPSecurityAlertInvalidContentLength", str );
 
     status = HTTP_PARSER_INTERNAL_ERROR;
     str = HTTPClient_strerror( status );

--- a/test/unit-test/core_http_utest.c
+++ b/test/unit-test/core_http_utest.c
@@ -1426,9 +1426,9 @@ void test_HTTPClient_strerror( void )
     str = HTTPClient_strerror( status );
     TEST_ASSERT_EQUAL_STRING( "HTTPSecurityAlertInvalidChunkHeader", str );
 
-    status = HTTP_SECURITY_ALERT_INVALID_PROTOCOL_VERSION;
+    status = HTTPSecurityAlertInvalidProtocolVersion;
     str = HTTPClient_strerror( status );
-    TEST_ASSERT_EQUAL_STRING( "HTTP_SECURITY_ALERT_INVALID_PROTOCOL_VERSION", str );
+    TEST_ASSERT_EQUAL_STRING( "HTTPSecurityAlertInvalidProtocolVersion", str );
 
     status = HTTP_SECURITY_ALERT_INVALID_STATUS_CODE;
     str = HTTPClient_strerror( status );

--- a/test/unit-test/core_http_utest.c
+++ b/test/unit-test/core_http_utest.c
@@ -1348,7 +1348,7 @@ void test_Http_ReadHeader_With_HttpParser_Internal_Error()
                                      HEADER_IN_BUFFER_LEN,
                                      &pValueLoc,
                                      &valueLen );
-    TEST_ASSERT_EQUAL( HTTP_PARSER_INTERNAL_ERROR, retCode );
+    TEST_ASSERT_EQUAL( HTTPParserInternalError, retCode );
 }
 
 /**
@@ -1442,9 +1442,9 @@ void test_HTTPClient_strerror( void )
     str = HTTPClient_strerror( status );
     TEST_ASSERT_EQUAL_STRING( "HTTPSecurityAlertInvalidContentLength", str );
 
-    status = HTTP_PARSER_INTERNAL_ERROR;
+    status = HTTPParserInternalError;
     str = HTTPClient_strerror( status );
-    TEST_ASSERT_EQUAL_STRING( "HTTP_PARSER_INTERNAL_ERROR", str );
+    TEST_ASSERT_EQUAL_STRING( "HTTPParserInternalError", str );
 
     status = HTTP_HEADER_NOT_FOUND;
     str = HTTPClient_strerror( status );

--- a/test/unit-test/core_http_utest.c
+++ b/test/unit-test/core_http_utest.c
@@ -458,36 +458,36 @@ void test_Http_InitializeRequestHeaders_Invalid_Params()
 
     /* Test NULL parameters, following order of else-if blocks. */
     httpStatus = HTTPClient_InitializeRequestHeaders( NULL, &requestInfo );
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, httpStatus );
+    TEST_ASSERT_EQUAL( HTTPInvalidParameter, httpStatus );
 
     /* TEST requestInfo.pBuffer == NULL */
     httpStatus = HTTPClient_InitializeRequestHeaders( &requestHeaders, &requestInfo );
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, httpStatus );
+    TEST_ASSERT_EQUAL( HTTPInvalidParameter, httpStatus );
     requestHeaders.pBuffer = testBuffer;
     requestHeaders.bufferLen = HTTP_TEST_INITIALIZED_HEADER_BUFFER_LEN;
 
     /* Test requestInfo == NULL. */
     httpStatus = HTTPClient_InitializeRequestHeaders( &requestHeaders, NULL );
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, httpStatus );
+    TEST_ASSERT_EQUAL( HTTPInvalidParameter, httpStatus );
 
     /* Test requestInfo.method == NULL. */
     httpStatus = HTTPClient_InitializeRequestHeaders( &requestHeaders, &requestInfo );
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, httpStatus );
+    TEST_ASSERT_EQUAL( HTTPInvalidParameter, httpStatus );
     requestInfo.method = HTTP_METHOD_GET;
 
     /* Test requestInfo.pHost == NULL. */
     httpStatus = HTTPClient_InitializeRequestHeaders( &requestHeaders, &requestInfo );
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, httpStatus );
+    TEST_ASSERT_EQUAL( HTTPInvalidParameter, httpStatus );
 
     /* Test requestInfo.methodLen == 0. */
     requestInfo.pHost = HTTP_TEST_HOST_VALUE;
     httpStatus = HTTPClient_InitializeRequestHeaders( &requestHeaders, &requestInfo );
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, httpStatus );
+    TEST_ASSERT_EQUAL( HTTPInvalidParameter, httpStatus );
 
     /* Test requestInfo.hostLen == 0. */
     requestInfo.methodLen = HTTP_METHOD_GET_LEN;
     httpStatus = HTTPClient_InitializeRequestHeaders( &requestHeaders, &requestInfo );
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, httpStatus );
+    TEST_ASSERT_EQUAL( HTTPInvalidParameter, httpStatus );
 }
 
 /**
@@ -640,14 +640,14 @@ void test_Http_AddHeader_Invalid_Params()
     httpStatus = HTTPClient_AddHeader( NULL,
                                        HTTP_TEST_HEADER_FIELD, HTTP_TEST_HEADER_FIELD_LEN,
                                        HTTP_TEST_HEADER_VALUE, HTTP_TEST_HEADER_VALUE_LEN );
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, httpStatus );
+    TEST_ASSERT_EQUAL( HTTPInvalidParameter, httpStatus );
 
     /* Test a NULL pBuffer member of request headers. */
     requestHeaders.pBuffer = NULL;
     httpStatus = HTTPClient_AddHeader( &requestHeaders,
                                        HTTP_TEST_HEADER_FIELD, HTTP_TEST_HEADER_FIELD_LEN,
                                        HTTP_TEST_HEADER_VALUE, HTTP_TEST_HEADER_VALUE_LEN );
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, httpStatus );
+    TEST_ASSERT_EQUAL( HTTPInvalidParameter, httpStatus );
 
     /* Test NULL header field. */
     requestHeaders.pBuffer = testBuffer;
@@ -655,32 +655,32 @@ void test_Http_AddHeader_Invalid_Params()
     httpStatus = HTTPClient_AddHeader( &requestHeaders,
                                        NULL, HTTP_TEST_HEADER_FIELD_LEN,
                                        HTTP_TEST_HEADER_VALUE, HTTP_TEST_HEADER_VALUE_LEN );
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, httpStatus );
+    TEST_ASSERT_EQUAL( HTTPInvalidParameter, httpStatus );
 
     /* Test NULL header value. */
     httpStatus = HTTPClient_AddHeader( &requestHeaders,
                                        HTTP_TEST_HEADER_FIELD, HTTP_TEST_HEADER_FIELD_LEN,
                                        NULL, HTTP_TEST_HEADER_VALUE_LEN );
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, httpStatus );
+    TEST_ASSERT_EQUAL( HTTPInvalidParameter, httpStatus );
 
     /* Test that fieldLen > 0. */
     httpStatus = HTTPClient_AddHeader( &requestHeaders,
                                        HTTP_TEST_HEADER_FIELD, 0,
                                        HTTP_TEST_HEADER_VALUE, HTTP_TEST_HEADER_VALUE_LEN );
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, httpStatus );
+    TEST_ASSERT_EQUAL( HTTPInvalidParameter, httpStatus );
 
     /* Test that valueLen > 0. */
     httpStatus = HTTPClient_AddHeader( &requestHeaders,
                                        HTTP_TEST_HEADER_FIELD, HTTP_TEST_HEADER_FIELD_LEN,
                                        HTTP_TEST_HEADER_VALUE, 0 );
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, httpStatus );
+    TEST_ASSERT_EQUAL( HTTPInvalidParameter, httpStatus );
 
     /* Test that requestHeaders.headersLen <= requestHeaders.bufferLen. */
     requestHeaders.headersLen = requestHeaders.bufferLen + 1;
     httpStatus = HTTPClient_AddHeader( &requestHeaders,
                                        HTTP_TEST_HEADER_FIELD, HTTP_TEST_HEADER_FIELD_LEN,
                                        HTTP_TEST_HEADER_VALUE, HTTP_TEST_HEADER_VALUE_LEN );
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, httpStatus );
+    TEST_ASSERT_EQUAL( HTTPInvalidParameter, httpStatus );
 }
 
 /**
@@ -818,14 +818,14 @@ void test_Http_AddRangeHeader_Invalid_Params( void )
     retCode = HTTPClient_AddRangeHeader( NULL,
                                          0 /* rangeStart */,
                                          0 /* rangeEnd */ );
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, retCode );
+    TEST_ASSERT_EQUAL( HTTPInvalidParameter, retCode );
 
     /* Underlying buffer is NULL in request headers. */
     tearDown();
     retCode = HTTPClient_AddRangeHeader( &testHeaders,
                                          0 /* rangeStart */,
                                          0 /* rangeEnd */ );
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, retCode );
+    TEST_ASSERT_EQUAL( HTTPInvalidParameter, retCode );
 
     /* Request Header Size is zero. */
     tearDown();
@@ -845,7 +845,7 @@ void test_Http_AddRangeHeader_Invalid_Params( void )
     retCode = HTTPClient_AddRangeHeader( &testHeaders,
                                          0 /* rangeStart */,
                                          10 /* rangeEnd */ );
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, retCode );
+    TEST_ASSERT_EQUAL( HTTPInvalidParameter, retCode );
 
     /* Test incorrect combinations of rangeStart and rangeEnd. */
 
@@ -855,7 +855,7 @@ void test_Http_AddRangeHeader_Invalid_Params( void )
     retCode = HTTPClient_AddRangeHeader( &testHeaders,
                                          10 /* rangeStart */,
                                          5 /* rangeEnd */ );
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, retCode );
+    TEST_ASSERT_EQUAL( HTTPInvalidParameter, retCode );
 
     /* rangeStart == INT32_MIN */
     tearDown();
@@ -863,7 +863,7 @@ void test_Http_AddRangeHeader_Invalid_Params( void )
     retCode = HTTPClient_AddRangeHeader( &testHeaders,
                                          INT32_MIN /* rangeStart */,
                                          HTTP_RANGE_REQUEST_END_OF_FILE /* rangeEnd */ );
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, retCode );
+    TEST_ASSERT_EQUAL( HTTPInvalidParameter, retCode );
 
     /* rangeStart is negative but rangeStart is non-End of File. */
     tearDown();
@@ -871,13 +871,13 @@ void test_Http_AddRangeHeader_Invalid_Params( void )
     retCode = HTTPClient_AddRangeHeader( &testHeaders,
                                          -10 /* rangeStart */,
                                          HTTP_RANGE_REQUEST_END_OF_FILE + 1 /* rangeEnd */ );
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, retCode );
+    TEST_ASSERT_EQUAL( HTTPInvalidParameter, retCode );
     tearDown();
     testHeaders.pBuffer = &testBuffer[ 0 ];
     retCode = HTTPClient_AddRangeHeader( &testHeaders,
                                          -50 /* rangeStart */,
                                          -10 /* rangeEnd */ );
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, retCode );
+    TEST_ASSERT_EQUAL( HTTPInvalidParameter, retCode );
 }
 
 /**
@@ -1132,7 +1132,7 @@ void test_Http_ReadHeader_Invalid_Params( void )
                                      HEADER_INVALID_PARAMS_LEN,
                                      &pValueLoc,
                                      &valueLen );
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, retCode );
+    TEST_ASSERT_EQUAL( HTTPInvalidParameter, retCode );
 
     /* Underlying buffer is NULL in the response parameter. */
     tearDown();
@@ -1142,7 +1142,7 @@ void test_Http_ReadHeader_Invalid_Params( void )
                                      HEADER_INVALID_PARAMS_LEN,
                                      &pValueLoc,
                                      &valueLen );
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, retCode );
+    TEST_ASSERT_EQUAL( HTTPInvalidParameter, retCode );
 
     /* Response buffer size is zero. */
     tearDown();
@@ -1152,7 +1152,7 @@ void test_Http_ReadHeader_Invalid_Params( void )
                                      HEADER_INVALID_PARAMS_LEN,
                                      &pValueLoc,
                                      &valueLen );
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, retCode );
+    TEST_ASSERT_EQUAL( HTTPInvalidParameter, retCode );
 
     /* Header field name is NULL. */
     tearDown();
@@ -1161,7 +1161,7 @@ void test_Http_ReadHeader_Invalid_Params( void )
                                      HEADER_INVALID_PARAMS_LEN,
                                      &pValueLoc,
                                      &valueLen );
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, retCode );
+    TEST_ASSERT_EQUAL( HTTPInvalidParameter, retCode );
 
     /* Header field length is 0. */
     tearDown();
@@ -1170,7 +1170,7 @@ void test_Http_ReadHeader_Invalid_Params( void )
                                      0u,
                                      &pValueLoc,
                                      &valueLen );
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, retCode );
+    TEST_ASSERT_EQUAL( HTTPInvalidParameter, retCode );
 
     /* Invalid output parameters. */
     tearDown();
@@ -1179,14 +1179,14 @@ void test_Http_ReadHeader_Invalid_Params( void )
                                      HEADER_INVALID_PARAMS_LEN,
                                      NULL,
                                      &valueLen );
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, retCode );
+    TEST_ASSERT_EQUAL( HTTPInvalidParameter, retCode );
     tearDown();
     retCode = HTTPClient_ReadHeader( &testResponse,
                                      HEADER_INVALID_PARAMS,
                                      HEADER_INVALID_PARAMS_LEN,
                                      &pValueLoc,
                                      NULL );
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, retCode );
+    TEST_ASSERT_EQUAL( HTTPInvalidParameter, retCode );
 }
 
 /**
@@ -1394,9 +1394,9 @@ void test_HTTPClient_strerror( void )
     str = HTTPClient_strerror( status );
     TEST_ASSERT_EQUAL_STRING( "HTTPSuccess", str );
 
-    status = HTTP_INVALID_PARAMETER;
+    status = HTTPInvalidParameter;
     str = HTTPClient_strerror( status );
-    TEST_ASSERT_EQUAL_STRING( "HTTP_INVALID_PARAMETER", str );
+    TEST_ASSERT_EQUAL_STRING( "HTTPInvalidParameter", str );
 
     status = HTTP_NETWORK_ERROR;
     str = HTTPClient_strerror( status );

--- a/test/unit-test/core_http_utest.c
+++ b/test/unit-test/core_http_utest.c
@@ -1430,9 +1430,9 @@ void test_HTTPClient_strerror( void )
     str = HTTPClient_strerror( status );
     TEST_ASSERT_EQUAL_STRING( "HTTPSecurityAlertInvalidProtocolVersion", str );
 
-    status = HTTP_SECURITY_ALERT_INVALID_STATUS_CODE;
+    status = HTTPSecurityAlertInvalidStatusCode;
     str = HTTPClient_strerror( status );
-    TEST_ASSERT_EQUAL_STRING( "HTTP_SECURITY_ALERT_INVALID_STATUS_CODE", str );
+    TEST_ASSERT_EQUAL_STRING( "HTTPSecurityAlertInvalidStatusCode", str );
 
     status = HTTP_SECURITY_ALERT_INVALID_CHARACTER;
     str = HTTPClient_strerror( status );

--- a/test/unit-test/core_http_utest.c
+++ b/test/unit-test/core_http_utest.c
@@ -1284,7 +1284,7 @@ void test_Http_ReadHeader_Invalid_Response_Only_Header_Field_Found()
                                      HEADER_IN_BUFFER_LEN,
                                      &pValueLoc,
                                      &valueLen );
-    TEST_ASSERT_EQUAL( HTTP_INVALID_RESPONSE, retCode );
+    TEST_ASSERT_EQUAL( HTTPInvalidResponse, retCode );
 }
 
 /**
@@ -1317,7 +1317,7 @@ void test_Http_ReadHeader_Invalid_Response_No_Headers_Complete_Ending()
                                      HEADER_NOT_IN_BUFFER_LEN,
                                      &pValueLoc,
                                      &valueLen );
-    TEST_ASSERT_EQUAL( HTTP_INVALID_RESPONSE, retCode );
+    TEST_ASSERT_EQUAL( HTTPInvalidResponse, retCode );
 }
 
 /**
@@ -1450,11 +1450,11 @@ void test_HTTPClient_strerror( void )
     str = HTTPClient_strerror( status );
     TEST_ASSERT_EQUAL_STRING( "HTTPHeaderNotFound", str );
 
-    status = HTTP_INVALID_RESPONSE;
+    status = HTTPInvalidResponse;
     str = HTTPClient_strerror( status );
-    TEST_ASSERT_EQUAL_STRING( "HTTP_INVALID_RESPONSE", str );
+    TEST_ASSERT_EQUAL_STRING( "HTTPInvalidResponse", str );
 
-    status = HTTP_INVALID_RESPONSE + 1;
+    status = HTTPInvalidResponse + 1;
     str = HTTPClient_strerror( status );
     TEST_ASSERT_EQUAL_STRING( NULL, str );
 }

--- a/test/unit-test/core_http_utest.c
+++ b/test/unit-test/core_http_utest.c
@@ -1414,9 +1414,9 @@ void test_HTTPClient_strerror( void )
     str = HTTPClient_strerror( status );
     TEST_ASSERT_EQUAL_STRING( "HTTPInsufficientMemory", str );
 
-    status = HTTP_SECURITY_ALERT_RESPONSE_HEADERS_SIZE_LIMIT_EXCEEDED;
+    status = HTTPSecurityAlertResponseHeadersSizeLimitExceeded;
     str = HTTPClient_strerror( status );
-    TEST_ASSERT_EQUAL_STRING( "HTTP_SECURITY_ALERT_RESPONSE_HEADERS_SIZE_LIMIT_EXCEEDED", str );
+    TEST_ASSERT_EQUAL_STRING( "HTTPSecurityAlertResponseHeadersSizeLimitExceeded", str );
 
     status = HTTP_SECURITY_ALERT_EXTRANEOUS_RESPONSE_DATA;
     str = HTTPClient_strerror( status );

--- a/test/unit-test/core_http_utest.c
+++ b/test/unit-test/core_http_utest.c
@@ -1398,9 +1398,9 @@ void test_HTTPClient_strerror( void )
     str = HTTPClient_strerror( status );
     TEST_ASSERT_EQUAL_STRING( "HTTPInvalidParameter", str );
 
-    status = HTTP_NETWORK_ERROR;
+    status = HTTPNetworkError;
     str = HTTPClient_strerror( status );
-    TEST_ASSERT_EQUAL_STRING( "HTTP_NETWORK_ERROR", str );
+    TEST_ASSERT_EQUAL_STRING( "HTTPNetworkError", str );
 
     status = HTTP_PARTIAL_RESPONSE;
     str = HTTPClient_strerror( status );

--- a/test/unit-test/core_http_utest.c
+++ b/test/unit-test/core_http_utest.c
@@ -1434,9 +1434,9 @@ void test_HTTPClient_strerror( void )
     str = HTTPClient_strerror( status );
     TEST_ASSERT_EQUAL_STRING( "HTTPSecurityAlertInvalidStatusCode", str );
 
-    status = HTTP_SECURITY_ALERT_INVALID_CHARACTER;
+    status = HTTPSecurityAlertInvalidCharacter;
     str = HTTPClient_strerror( status );
-    TEST_ASSERT_EQUAL_STRING( "HTTP_SECURITY_ALERT_INVALID_CHARACTER", str );
+    TEST_ASSERT_EQUAL_STRING( "HTTPSecurityAlertInvalidCharacter", str );
 
     status = HTTP_SECURITY_ALERT_INVALID_CONTENT_LENGTH;
     str = HTTPClient_strerror( status );


### PR DESCRIPTION
The enums in the HTTP Client library were following the CSDK v4_beta style upon initial development. The enum style then was to make them all caps because they are constants.
The [new style guide](https://docs.aws.amazon.com/freertos/latest/lib-ref/embedded-csdk/202009.00/lib-ref/docs/doxygen/output/html/guide_developer_styleguide.html) directs enum values for libraries to be in camel case. 

This PR updates all of the status enums for consistency.

**Next steps:**  
Update submodule in CSDK and update usage everywhere there in all integ tests and demos.