### PR TITLE
Remove const qualifier from send/recv in transport interface

### DIFF
--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -229,13 +229,13 @@ following functions pointers:
  - [Transport Receive](@ref TransportRecv_t): A function to receive bytes from a network.
  @code
  int32_t (* TransportRecv_t )(
-     const NetworkContext_t * pNetworkContext, void * pBuffer, size_t bytesToRecv
+     NetworkContext_t * pNetworkContext, void * pBuffer, size_t bytesToRecv
  );
  @endcode
  - [Transport Send](@ref TransportSend_t): A function to send bytes over a network.
  @code
  int32_t (* TransportSend_t )(
-     const NetworkContext_t * pNetworkContext, const void * pBuffer, size_t bytesToSend
+     NetworkContext_t * pNetworkContext, const void * pBuffer, size_t bytesToSend
  );
  @endcode
 

--- a/source/portable/transport_interface.h
+++ b/source/portable/transport_interface.h
@@ -91,7 +91,7 @@
  * <br><br>
  * <b>Example code:</b>
  * @code{c}
- * int32_t myNetworkRecvImplementation( const NetworkContext_t * pNetworkContext,
+ * int32_t myNetworkRecvImplementation( NetworkContext_t * pNetworkContext,
  *                                      void * pBuffer,
  *                                      size_t bytesToRecv )
  * {
@@ -123,7 +123,7 @@
  * <br><br>
  * <b>Example code:</b>
  * @code{c}
- * int32_t myNetworkSendImplementation( const NetworkContext_t * pNetworkContext,
+ * int32_t myNetworkSendImplementation( NetworkContext_t * pNetworkContext,
  *                                      const void * pBuffer,
  *                                      size_t bytesToSend )
  * {
@@ -166,7 +166,7 @@ typedef struct NetworkContext NetworkContext_t;
  * @return The number of bytes received or a negative error code.
  */
 /* @[define_transportrecv] */
-typedef int32_t ( * TransportRecv_t )( const NetworkContext_t * pNetworkContext,
+typedef int32_t ( * TransportRecv_t )( NetworkContext_t * pNetworkContext,
                                        void * pBuffer,
                                        size_t bytesToRecv );
 /* @[define_transportrecv] */
@@ -182,7 +182,7 @@ typedef int32_t ( * TransportRecv_t )( const NetworkContext_t * pNetworkContext,
  * @return The number of bytes sent or a negative error code.
  */
 /* @[define_transportsend] */
-typedef int32_t ( * TransportSend_t )( const NetworkContext_t * pNetworkContext,
+typedef int32_t ( * TransportSend_t )( NetworkContext_t * pNetworkContext,
                                        const void * pBuffer,
                                        size_t bytesToSend );
 /* @[define_transportsend] */

--- a/test/unit-test/core_http_send_utest.c
+++ b/test/unit-test/core_http_send_utest.c
@@ -261,7 +261,7 @@ static void onHeaderCallback( void * pContext,
 }
 
 /* Successful application transport send interface. */
-static int32_t transportSendSuccess( const NetworkContext_t * pNetworkContext,
+static int32_t transportSendSuccess( NetworkContext_t * pNetworkContext,
                                      const void * pBuffer,
                                      size_t bytesToWrite )
 {
@@ -287,7 +287,7 @@ static int32_t transportSendSuccess( const NetworkContext_t * pNetworkContext,
 /* Application transport send interface that returns a network error depending
 * on the call count. Set sendErrorCall to 0 to return an error on the
 * first call. Set sendErrorCall to 1 to return an error on the second call. */
-static int32_t transportSendNetworkError( const NetworkContext_t * pNetworkContext,
+static int32_t transportSendNetworkError( NetworkContext_t * pNetworkContext,
                                           const void * pBuffer,
                                           size_t bytesToWrite )
 {
@@ -308,7 +308,7 @@ static int32_t transportSendNetworkError( const NetworkContext_t * pNetworkConte
  * depending on the call count. Set sendPartialCall to 0 to return less bytes on
  * the first call. Set sendPartialCall to 1 to return less bytes on the second
  * call. */
-static int32_t transportSendLessThanBytesToWrite( const NetworkContext_t * pNetworkContext,
+static int32_t transportSendLessThanBytesToWrite( NetworkContext_t * pNetworkContext,
                                                   const void * pBuffer,
                                                   size_t bytesToWrite )
 {
@@ -330,7 +330,7 @@ static int32_t transportSendLessThanBytesToWrite( const NetworkContext_t * pNetw
  * second call. The response to send is set in pNetworkData and the current
  * call count is kept track of in recvCurrentCall. This function will return
  * zero (timeout condition) when recvStopCall matches recvCurrentCall. */
-static int32_t transportRecvSuccess( const NetworkContext_t * pNetworkContext,
+static int32_t transportRecvSuccess( NetworkContext_t * pNetworkContext,
                                      void * pBuffer,
                                      size_t bytesToRead )
 {
@@ -368,7 +368,7 @@ static int32_t transportRecvSuccess( const NetworkContext_t * pNetworkContext,
 }
 
 /* Application transport receive that return a network error. */
-static int32_t transportRecvNetworkError( const NetworkContext_t * pNetworkContext,
+static int32_t transportRecvNetworkError( NetworkContext_t * pNetworkContext,
                                           void * pBuffer,
                                           size_t bytesToRead )
 {


### PR DESCRIPTION
This follows changes from [https://github.com/FreeRTOS/coreMQTT/pull/86](https://github.com/FreeRTOS/coreMQTT/pull/86) & [https://github.com/FreeRTOS/FreeRTOS/commit/398abbaa6199a12377a6254b197ab12f9788cc32](https://github.com/FreeRTOS/FreeRTOS/commit/398abbaa6199a12377a6254b197ab12f9788cc32). The const qualifier is removed from send/recv because there are transport implementations that require a member of the network context to be modified such as in the case of mbedtls.