### PR TITLE
Fix some issues found by Coverity MISRA

### DIFF
--- a/lexicon.txt
+++ b/lexicon.txt
@@ -213,6 +213,7 @@ snprintf
 statuscode
 strchr
 strerror
+strncpy
 struct
 sublicense
 tcp

--- a/source/core_http_client.c
+++ b/source/core_http_client.c
@@ -1218,14 +1218,11 @@ static HTTPStatus_t addHeader( HTTPRequestHeaders_t * pRequestHeaders,
     {
         /* Write "<Field>: <Value> \r\n" to the headers buffer. */
 
-        /* Copy the header name into the buffer. memcpy can be used here, but
-         * for consistency with the rest of the function we use strncpy. */
+        /* Copy the header name into the buffer. */
         ( void ) strncpy( pBufferCur, pField, fieldLen );
         pBufferCur += fieldLen;
 
-        /* Copy the field separator, ": ", into the buffer. We use strncpy,
-         * instead of memcpy, here and for other string literal copies in this
-         * function, because this satisfies MISRA rule 7.4. */
+        /* Copy the field separator, ": ", into the buffer. */
         ( void ) strncpy( pBufferCur,
                           HTTP_HEADER_FIELD_SEPARATOR,
                           HTTP_HEADER_FIELD_SEPARATOR_LEN );
@@ -1275,8 +1272,7 @@ static HTTPStatus_t addRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
 
     /* Generate the value data for the Range Request header.*/
 
-    /* Write the range value prefix in the buffer. We use strncpy here instead
-     * of memcpy because this satisfies MISRA rule 7.4. */
+    /* Write the range value prefix in the buffer. */
     ( void ) strncpy( rangeValueBuffer,
                       HTTP_RANGE_REQUEST_HEADER_VALUE_PREFIX,
                       HTTP_RANGE_REQUEST_HEADER_VALUE_PREFIX_LEN );
@@ -1353,18 +1349,14 @@ static HTTPStatus_t writeRequestLine( HTTPRequestHeaders_t * pRequestHeaders,
 
     if( returnStatus == HTTPSuccess )
     {
-        /* Write "<METHOD> <PATH> HTTP/1.1\r\n" to start the HTTP header. memcpy
-         * can be used here, but, for consistency with the rest of the function,
-         * we use strncpy. */
+        /* Write "<METHOD> <PATH> HTTP/1.1\r\n" to start the HTTP header. */
         ( void ) strncpy( pBufferCur, pMethod, methodLen );
         pBufferCur += methodLen;
 
         *pBufferCur = SPACE_CHARACTER;
         pBufferCur += SPACE_CHARACTER_LEN;
 
-        /* Use "/" as default value if <PATH> is NULL. We use strncpy, instead
-         * of memcpy, here and for other string literal copies in this function,
-         * because this satisfies MISRA rule 7.4. */
+        /* Use "/" as default value if <PATH> is NULL. */
         if( ( pPath == NULL ) || ( pathLen == 0u ) )
         {
             ( void ) strncpy( pBufferCur,
@@ -2002,8 +1994,9 @@ HTTPStatus_t HTTPClient_Send( const TransportInterface_t * pTransport,
     {
         /* This check is needed because convertInt32ToAscii() is used on the
          * reqBodyBufLen to create a Content-Length header value string. */
-        LogError( ( "Parameter check failed: reqBodyBufLen > "
-                    "2147483647 (INT32_MAX)." ) );
+        LogError( ( "Parameter check failed: reqBodyBufLen > INT32_MAX."
+                    "reqBodyBufLen=%lu",
+                    ( unsigned long ) reqBodyBufLen ) );
         returnStatus = HTTPInvalidParameter;
     }
     else
@@ -2250,8 +2243,6 @@ static HTTPStatus_t findHeaderInResponse( const uint8_t * pBuffer,
                     pField,
                     ( int ) ( *pValueLen ),
                     *pValueLoc ) );
-
-        /* MISRA 15.7 requires a non-empty terminating else for this block. */
         returnStatus = HTTPSuccess;
     }
 

--- a/source/core_http_client.c
+++ b/source/core_http_client.c
@@ -1265,9 +1265,10 @@ static HTTPStatus_t addRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
 
     assert( pRequestHeaders != NULL );
 
-    /* This buffer uses a char type instead of the general purpose uint8_t because
-    * the range value expected to be written is within the ASCII character set. */
-    ( void ) memset( rangeValueBuffer, '\0', HTTP_MAX_RANGE_REQUEST_VALUE_LEN );
+    /* This buffer uses a char type instead of the general purpose uint8_t
+     * because the range value expected to be written is within the ASCII
+     * character set. */
+    ( void ) memset( rangeValueBuffer, ( int ) '\0', HTTP_MAX_RANGE_REQUEST_VALUE_LEN );
 
     /* Generate the value data for the Range Request header.*/
 
@@ -1723,19 +1724,9 @@ static HTTPStatus_t sendHttpHeaders( const TransportInterface_t * pTransport,
 
     if( returnStatus == HTTPSuccess )
     {
-        /* Send the HTTP headers over the network. */
-        if( pRequestHeaders->headersLen > INT32_MAX )
-        {
-            LogError( ( "Parameter check failed: pRequestHeaders->headersLen > "
-                        "2147483647 (INT32_MAX)." ) );
-            returnStatus = HTTPInvalidParameter;
-        }
-        else
-        {
-            LogDebug( ( "Sending HTTP request headers: HeaderBytes=%lu",
-                        ( unsigned long ) ( pRequestHeaders->headersLen ) ) );
-            returnStatus = sendHttpData( pTransport, pRequestHeaders->pBuffer, pRequestHeaders->headersLen );
-        }
+        LogDebug( ( "Sending HTTP request headers: HeaderBytes=%lu",
+                    ( unsigned long ) ( pRequestHeaders->headersLen ) ) );
+        returnStatus = sendHttpData( pTransport, pRequestHeaders->pBuffer, pRequestHeaders->headersLen );
     }
 
     return returnStatus;
@@ -1999,7 +1990,7 @@ HTTPStatus_t HTTPClient_Send( const TransportInterface_t * pTransport,
                     "reqBodyBufLen is greater than zero." ) );
         returnStatus = HTTPInvalidParameter;
     }
-    else if( reqBodyBufLen > INT32_MAX )
+    else if( reqBodyBufLen > ( size_t ) ( INT32_MAX ) )
     {
         /* This check is needed because convertInt32ToAscii() is used on the
          * reqBodyBufLen to create a Content-Length header value string. */
@@ -2242,9 +2233,6 @@ static HTTPStatus_t findHeaderInResponse( const uint8_t * pBuffer,
     }
     else
     {
-        /* Empty else (when assert and logging is disabled) for MISRA 15.7
-         * compliance. */
-
         /* Header is found. */
         assert( ( context.fieldFound == 1u ) && ( context.valueFound == 1u ) );
 
@@ -2254,6 +2242,9 @@ static HTTPStatus_t findHeaderInResponse( const uint8_t * pBuffer,
                     pField,
                     ( int ) ( *pValueLen ),
                     *pValueLoc ) );
+
+        /* MISRA 15.7 requres a non-empty terminating else for this block. */
+        returnStatus = HTTPSuccess;
     }
 
     /* If the header field-value pair is found in response, then the return

--- a/source/core_http_client.c
+++ b/source/core_http_client.c
@@ -2243,7 +2243,7 @@ static HTTPStatus_t findHeaderInResponse( const uint8_t * pBuffer,
                     ( int ) ( *pValueLen ),
                     *pValueLoc ) );
 
-        /* MISRA 15.7 requres a non-empty terminating else for this block. */
+        /* MISRA 15.7 requires a non-empty terminating else for this block. */
         returnStatus = HTTPSuccess;
     }
 

--- a/source/core_http_client.c
+++ b/source/core_http_client.c
@@ -1218,24 +1218,27 @@ static HTTPStatus_t addHeader( HTTPRequestHeaders_t * pRequestHeaders,
     {
         /* Write "<Field>: <Value> \r\n" to the headers buffer. */
 
-        /* Copy the header name into the buffer. */
-        ( void ) memcpy( pBufferCur, pField, fieldLen );
+        /* Copy the header name into the buffer. memcpy can be used here, but
+         * for consistency with the rest of the function we use strncpy. */
+        ( void ) strncpy( pBufferCur, pField, fieldLen );
         pBufferCur += fieldLen;
 
-        /* Copy the field separator, ": ", into the buffer. */
-        ( void ) memcpy( pBufferCur,
-                         HTTP_HEADER_FIELD_SEPARATOR,
-                         HTTP_HEADER_FIELD_SEPARATOR_LEN );
+        /* Copy the field separator, ": ", into the buffer. We use strncpy,
+         * instead of memcpy, here and for other string literal copies in this
+         * function, because this satisfies MISRA rule 7.4. */
+        ( void ) strncpy( pBufferCur,
+                          HTTP_HEADER_FIELD_SEPARATOR,
+                          HTTP_HEADER_FIELD_SEPARATOR_LEN );
         pBufferCur += HTTP_HEADER_FIELD_SEPARATOR_LEN;
 
         /* Copy the header value into the buffer. */
-        ( void ) memcpy( pBufferCur, pValue, valueLen );
+        ( void ) strncpy( pBufferCur, pValue, valueLen );
         pBufferCur += valueLen;
 
         /* Copy the header end indicator, "\r\n\r\n" into the buffer. */
-        ( void ) memcpy( pBufferCur,
-                         HTTP_HEADER_END_INDICATOR,
-                         HTTP_HEADER_END_INDICATOR_LEN );
+        ( void ) strncpy( pBufferCur,
+                          HTTP_HEADER_END_INDICATOR,
+                          HTTP_HEADER_END_INDICATOR_LEN );
 
         /* Update the headers length value. */
         pRequestHeaders->headersLen = backtrackHeaderLen + toAddLen;
@@ -1272,10 +1275,11 @@ static HTTPStatus_t addRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
 
     /* Generate the value data for the Range Request header.*/
 
-    /* Write the range value prefix in the buffer. */
-    ( void ) memcpy( rangeValueBuffer,
-                     HTTP_RANGE_REQUEST_HEADER_VALUE_PREFIX,
-                     HTTP_RANGE_REQUEST_HEADER_VALUE_PREFIX_LEN );
+    /* Write the range value prefix in the buffer. We use strncpy here instead
+     * of memcpy because this satisfies MISRA rule 7.4. */
+    ( void ) strncpy( rangeValueBuffer,
+                      HTTP_RANGE_REQUEST_HEADER_VALUE_PREFIX,
+                      HTTP_RANGE_REQUEST_HEADER_VALUE_PREFIX_LEN );
     rangeValueLength += HTTP_RANGE_REQUEST_HEADER_VALUE_PREFIX_LEN;
 
     /* Write the range start value in the buffer. */
@@ -1349,38 +1353,42 @@ static HTTPStatus_t writeRequestLine( HTTPRequestHeaders_t * pRequestHeaders,
 
     if( returnStatus == HTTPSuccess )
     {
-        /* Write "<METHOD> <PATH> HTTP/1.1\r\n" to start the HTTP header. */
-        ( void ) memcpy( pBufferCur, pMethod, methodLen );
+        /* Write "<METHOD> <PATH> HTTP/1.1\r\n" to start the HTTP header. memcpy
+         * can be used here, but, for consistency with the rest of the function,
+         * we use strncpy. */
+        ( void ) strncpy( pBufferCur, pMethod, methodLen );
         pBufferCur += methodLen;
 
         *pBufferCur = SPACE_CHARACTER;
         pBufferCur += SPACE_CHARACTER_LEN;
 
-        /* Use "/" as default value if <PATH> is NULL. */
+        /* Use "/" as default value if <PATH> is NULL. We use strncpy, instead
+         * of memcpy, here and for other string literal copies in this function,
+         * because this satisfies MISRA rule 7.4. */
         if( ( pPath == NULL ) || ( pathLen == 0u ) )
         {
-            ( void ) memcpy( pBufferCur,
-                             HTTP_EMPTY_PATH,
-                             HTTP_EMPTY_PATH_LEN );
+            ( void ) strncpy( pBufferCur,
+                              HTTP_EMPTY_PATH,
+                              HTTP_EMPTY_PATH_LEN );
             pBufferCur += HTTP_EMPTY_PATH_LEN;
         }
         else
         {
-            ( void ) memcpy( pBufferCur, pPath, pathLen );
+            ( void ) strncpy( pBufferCur, pPath, pathLen );
             pBufferCur += pathLen;
         }
 
         *pBufferCur = SPACE_CHARACTER;
         pBufferCur += SPACE_CHARACTER_LEN;
 
-        ( void ) memcpy( pBufferCur,
-                         HTTP_PROTOCOL_VERSION,
-                         HTTP_PROTOCOL_VERSION_LEN );
+        ( void ) strncpy( pBufferCur,
+                          HTTP_PROTOCOL_VERSION,
+                          HTTP_PROTOCOL_VERSION_LEN );
         pBufferCur += HTTP_PROTOCOL_VERSION_LEN;
 
-        ( void ) memcpy( pBufferCur,
-                         HTTP_HEADER_LINE_SEPARATOR,
-                         HTTP_HEADER_LINE_SEPARATOR_LEN );
+        ( void ) strncpy( pBufferCur,
+                          HTTP_HEADER_LINE_SEPARATOR,
+                          HTTP_HEADER_LINE_SEPARATOR_LEN );
         pRequestHeaders->headersLen = toAddLen;
     }
 

--- a/test/cbmc/proofs/HTTPClient_AddHeader/HTTPClient_AddHeader_harness.c
+++ b/test/cbmc/proofs/HTTPClient_AddHeader/HTTPClient_AddHeader_harness.c
@@ -42,11 +42,11 @@ void HTTPClient_AddHeader_harness()
     __CPROVER_assume( isValidHttpRequestHeaders( pRequestHeaders ) );
 
     /* Initialize and make assumptions for header field. */
-    __CPROVER_assume( fieldLen < CBMC_MAX_OBJECT_SIZE );
+    __CPROVER_assume( fieldLen < HEADER_FIELD_MAX_LENGTH );
     pField = mallocCanFail( fieldLen );
 
     /* Initialize and make assumptions for header value. */
-    __CPROVER_assume( valueLen < CBMC_MAX_OBJECT_SIZE );
+    __CPROVER_assume( valueLen < HEADER_VALUE_MAX_LENGTH );
     pValue = mallocCanFail( valueLen );
 
     HTTPClient_AddHeader( pRequestHeaders,

--- a/test/cbmc/proofs/HTTPClient_AddHeader/Makefile
+++ b/test/cbmc/proofs/HTTPClient_AddHeader/Makefile
@@ -23,7 +23,17 @@ HARNESS_ENTRY=HTTPClient_AddHeader_harness
 PROOF_UID=HTTPClient_AddHeader
 HARNESS_FILE=$(HARNESS_ENTRY)
 
-DEFINES +=
+# The header field and value string lengths input into HTTPClient_AddHeader are
+# bounded to reduce the proof run time. This length is a bound on the strncpys
+# used to write the header field and values to the request header buffer. Memory
+# safety on the request header buffer can be proven in a reasonable bound. It
+# adds no value to the proof to write a header field and a header value of
+# SIZE_MAX length.
+HEADER_FIELD_MAX_LENGTH=16
+HEADER_VALUE_MAX_LENGTH=16
+
+DEFINES += -DHEADER_FIELD_MAX_LENGTH=$(HEADER_FIELD_MAX_LENGTH)
+DEFINES += -DHEADER_VALUE_MAX_LENGTH=$(HEADER_VALUE_MAX_LENGTH)
 INCLUDES +=
 
 # We remove these function bodies so that they aren't categorized as possible
@@ -39,13 +49,13 @@ REMOVE_FUNCTION_BODY += __CPROVER_file_local_core_http_client_c_httpParserOnHead
 REMOVE_FUNCTION_BODY += __CPROVER_file_local_core_http_client_c_httpParserOnMessageBeginCallback
 REMOVE_FUNCTION_BODY += __CPROVER_file_local_core_http_client_c_httpParserOnMessageCompleteCallback
 
-REMOVE_FUNCTION_BODY += memcpy
-
+# strncmp is used to find if there exists "\r\n\r\n" at the end of the header
+# buffer. Therefore, we need to unwind strncmp the length of "\r\n\r\n" + 1.
 UNWINDSET += strncmp.0:5
+UNWINDSET += strncpy.0:$(HEADER_FIELD_MAX_LENGTH)
 
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROOF_SOURCES += $(SRCDIR)/test/cbmc/sources/http_cbmc_state.c
-PROOF_SOURCES += $(SRCDIR)/test/cbmc/stubs/memcpy.c
 
 PROJECT_SOURCES += $(SRCDIR)/source/core_http_client.c
 

--- a/test/cbmc/proofs/HTTPClient_AddRangeHeader/Makefile
+++ b/test/cbmc/proofs/HTTPClient_AddRangeHeader/Makefile
@@ -27,8 +27,14 @@ DEFINES +=
 INCLUDES +=
 
 REMOVE_FUNCTION_BODY +=
-# Maximum value of a 32 bit signed integer is 2,147,483,647, which is 10 digits.
+# strncmp is used to find if there exists "\r\n\r\n" at the end of the header
+# buffer. Therefore, we need to unwind strncmp the length of "\r\n\r\n" + 1.
 UNWINDSET += strncmp.0:5
+# The maximum number of characters expected to be copied is the maximum length
+# of the range header value. It is of the form:
+# "bytes=<Max-Integer-Value>-<Max-Integer-Value>".
+UNWINDSET += strncpy.0:28
+# Maximum value of a 32 bit signed integer is 2,147,483,647, which is 10 digits.
 UNWINDSET += __CPROVER_file_local_core_http_client_c_convertInt32ToAscii.0:11
 UNWINDSET += __CPROVER_file_local_core_http_client_c_convertInt32ToAscii.1:11
 

--- a/test/cbmc/proofs/HTTPClient_InitializeRequestHeaders/Makefile
+++ b/test/cbmc/proofs/HTTPClient_InitializeRequestHeaders/Makefile
@@ -38,13 +38,13 @@ REMOVE_FUNCTION_BODY += __CPROVER_file_local_core_http_client_c_httpParserOnHead
 REMOVE_FUNCTION_BODY += __CPROVER_file_local_core_http_client_c_httpParserOnMessageBeginCallback
 REMOVE_FUNCTION_BODY += __CPROVER_file_local_core_http_client_c_httpParserOnMessageCompleteCallback
 
-REMOVE_FUNCTION_BODY += memcpy
+REMOVE_FUNCTION_BODY += strncpy
 
 UNWINDSET += strncmp.0:5
 
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROOF_SOURCES += $(SRCDIR)/test/cbmc/sources/http_cbmc_state.c
-PROOF_SOURCES += $(SRCDIR)/test/cbmc/stubs/memcpy.c
+PROOF_SOURCES += $(SRCDIR)/test/cbmc/stubs/strncpy.c
 
 PROJECT_SOURCES += $(SRCDIR)/source/core_http_client.c
 

--- a/test/cbmc/proofs/HTTPClient_Send/Makefile
+++ b/test/cbmc/proofs/HTTPClient_Send/Makefile
@@ -52,7 +52,14 @@ UNWINDSET += __CPROVER_file_local_core_http_client_c_convertInt32ToAscii.0:11
 UNWINDSET += __CPROVER_file_local_core_http_client_c_convertInt32ToAscii.1:11
 UNWINDSET += __CPROVER_file_local_core_http_client_c_receiveAndParseHttpResponse.0:10
 UNWINDSET += __CPROVER_file_local_core_http_client_c_sendHttpData.0:10
+
+# strncmp is used to find if there exists "\r\n\r\n" at the end of the header
+# buffer. Therefore, we need to unwind strncmp to the length of "\r\n\r\n" + 1.
 UNWINDSET += strncmp.0:5
+# strncpy is used to write the Content-Length header field to the request before
+# sending it. Therefore, we need to unwind strncmp to the length of
+# "Content-Length" + 1.
+UNWINDSET += strncpy.0:15
 
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROOF_SOURCES += $(SRCDIR)/test/cbmc/sources/http_cbmc_state.c

--- a/test/cbmc/stubs/strncpy.c
+++ b/test/cbmc/stubs/strncpy.c
@@ -21,9 +21,10 @@
  */
 
 /**
- * @file memcpy.c
- * @brief Creates a stub for memcpy so that the proof for
- * HTTPClient_InitializeRequestHeaders runs much faster.
+ * @file strncpy.c
+ * @brief Creates a stub for strncpy so that the proof for
+ * HTTPClient_InitializeRequestHeaders runs much faster. This stub checks if the
+ * destination and source are valid accessible memory, for the length to copy.
  */
 
 #include <string.h>
@@ -33,18 +34,18 @@
     #define __has_builtin( x )    0
 #endif
 
-#if __has_builtin( __builtin___memcpy_chk )
-    void * __builtin___memcpy_chk( void * dest,
+#if __has_builtin( __builtin___strncpy_chk )
+    void * __builtin___strncpy_chk( void * dest,
                                    const void * src,
                                    size_t n,
-                                   size_t m )
+                                   size_t os )
     {
         __CPROVER_assert( __CPROVER_w_ok( dest, n ), "write" );
         __CPROVER_assert( __CPROVER_r_ok( src, n ), "read" );
         return dest;
     }
 #else
-    void * memcpy( void * dest,
+    void * strncpy( void * dest,
                    const void * src,
                    size_t n )
     {
@@ -52,4 +53,4 @@
         __CPROVER_assert( __CPROVER_r_ok( src, n ), "read" );
         return dest;
     }
-#endif /* if __has_builtin( __builtin___memcpy_chk ) */
+#endif /* if __has_builtin( __builtin___strncpy_chk ) */

--- a/test/cbmc/stubs/strncpy.c
+++ b/test/cbmc/stubs/strncpy.c
@@ -36,9 +36,9 @@
 
 #if __has_builtin( __builtin___strncpy_chk )
     void * __builtin___strncpy_chk( void * dest,
-                                   const void * src,
-                                   size_t n,
-                                   size_t os )
+                                    const void * src,
+                                    size_t n,
+                                    size_t os )
     {
         __CPROVER_assert( __CPROVER_w_ok( dest, n ), "write" );
         __CPROVER_assert( __CPROVER_r_ok( src, n ), "read" );
@@ -46,8 +46,8 @@
     }
 #else
     void * strncpy( void * dest,
-                   const void * src,
-                   size_t n )
+                    const void * src,
+                    size_t n )
     {
         __CPROVER_assert( __CPROVER_w_ok( dest, n ), "write" );
         __CPROVER_assert( __CPROVER_r_ok( src, n ), "read" );

--- a/test/cbmc/stubs/transport_interface_stubs.c
+++ b/test/cbmc/stubs/transport_interface_stubs.c
@@ -27,7 +27,7 @@ int32_t TransportInterfaceSendStub( NetworkContext_t * pNetworkContext,
                                     size_t bytesToSend )
 {
     /* The number of tries to send the message before this invocation */
-    static int32_t tries;
+    static int32_t tries = 0;
     /* The number of bytes considered sent after this invocation */
     int32_t ret;
 
@@ -48,14 +48,21 @@ int32_t TransportInterfaceSendStub( NetworkContext_t * pNetworkContext,
     * finish the message after MAX_TRIES tries.
     ****************************************************************/
 
-    __CPROVER_assume( ret <= ( int32_t ) bytesToSend );
+    if( bytesToSend <= INT32_MAX )
+    {
+        __CPROVER_assume( ret <= ( int32_t ) bytesToSend );
+    }
 
     tries++;
 
     if( tries >= MAX_TRIES )
     {
         tries = 0;
-        ret = bytesToSend;
+
+        /* In order to stop the looping on send we must return an error or
+         * bytesToSend. We return an error instead of bytesToSend because
+         * bytesToSend may be a value larger than INT32_MAX. */
+        ret = -1;
     }
 
     return ret;

--- a/test/unit-test/core_http_send_utest.c
+++ b/test/unit-test/core_http_send_utest.c
@@ -1424,28 +1424,6 @@ void test_HTTPClient_Send_not_enough_request_headers( void )
 
 /*-----------------------------------------------------------*/
 
-/* Test when length of headers is greater than the max value of a 32-bit integer. */
-void test_HTTPClient_Send_headers_length_gt_max( void )
-{
-    HTTPStatus_t returnStatus = HTTPSuccess;
-
-    requestHeaders.headersLen = INT32_MAX;
-    /* Increment separately to prevent an overflow warning. */
-    requestHeaders.headersLen++;
-    requestHeaders.bufferLen = requestHeaders.headersLen;
-
-    returnStatus = HTTPClient_Send( &transportInterface,
-                                    &requestHeaders,
-                                    NULL,
-                                    0,
-                                    &response,
-                                    0 );
-
-    TEST_ASSERT_EQUAL( HTTPInvalidParameter, returnStatus );
-}
-
-/*-----------------------------------------------------------*/
-
 /* Test a NULL request body but a non-zero requests body length.
  */
 void test_HTTPClient_Send_null_request_body_nonzero_body_length( void )


### PR DESCRIPTION
This PR fixes some outstanding issues found by Coverity MISRA. After this PR there will be only 45 rule violations in the core_http_client.c source, all of which are related to using non-compliant http-parser.

This includes:
- Making explicit casts in comparisons for size_t against a narrower type.
- Delete unnecessary comparison that was just a work around for cbmc's transport interface send stub.
- Change all memcpy to strncpy for MISRA rule 7.4.

[cov-out.zip](https://github.com/FreeRTOS/coreHTTP/files/5436854/cov-out.zip)
