### PR TITLE
Update HTTPClient_ReadHeader to allow empty header values

### DIFF
--- a/source/core_http_client.c
+++ b/source/core_http_client.c
@@ -2124,7 +2124,7 @@ static int findHeaderValueParserCallback( http_parser * pHttpParser,
         }
         else
         {
-            /* It is not invalid according to rfc2616 to have an empty header
+            /* It is not invalid according to RFC 2616 to have an empty header
              * value. */
             *pContext->pValueLoc = NULL;
             *pContext->pValueLen = 0;

--- a/source/core_http_client.c
+++ b/source/core_http_client.c
@@ -2098,7 +2098,6 @@ static int findHeaderValueParserCallback( http_parser * pHttpParser,
 
     assert( pHttpParser != NULL );
     assert( pValueLoc != NULL );
-    assert( valueLen > 0u );
 
     pContext = ( findHeaderContext_t * ) pHttpParser->data;
 
@@ -2116,9 +2115,20 @@ static int findHeaderValueParserCallback( http_parser * pHttpParser,
                     "RequestedField=%.*s, ValueLocation=0x%p",
                     ( int ) ( pContext->fieldLen ), pContext->pField, pValueLoc ) );
 
-        /* Populate the output parameters with the location of the header value in the response buffer. */
-        *pContext->pValueLoc = pValueLoc;
-        *pContext->pValueLen = valueLen;
+        if( valueLen > 0 )
+        {
+            /* Populate the output parameters with the location of the header
+             * value in the response buffer. */
+            *pContext->pValueLoc = pValueLoc;
+            *pContext->pValueLen = valueLen;
+        }
+        else
+        {
+            /* It is not invalid according to rfc2616 to have an empty header
+             * value. */
+            *pContext->pValueLoc = NULL;
+            *pContext->pValueLen = 0;
+        }
 
         /* Set the header value found flag. */
         pContext->valueFound = 1u;

--- a/source/include/core_http_client.h
+++ b/source/include/core_http_client.h
@@ -798,9 +798,9 @@ HTTPStatus_t HTTPClient_Send( const TransportInterface_t * pTransport,
  * This will return the location of the response header value in the
  * #HTTPResponse_t.pBuffer buffer.
  *
- * The location within #HTTPResponse_t.pBuffer, of the value found, will be
- * returned in @p pValue. If the value empty, for the @p pField found, then this
- * function will return #HTTPSuccess and @p pValue will be set to NULL with
+ * The location, within #HTTPResponse_t.pBuffer, of the value found, will be
+ * returned in @p pValue. If the value is empty, for the @p pField found, then
+ * this function will return #HTTPSuccess and @p pValue will be set to NULL with
  * @p pValueLen set to zero. According to RFC 2616 it is not invalid to have an
  * empty value for some header fields.
  *

--- a/source/include/core_http_client.h
+++ b/source/include/core_http_client.h
@@ -798,6 +798,12 @@ HTTPStatus_t HTTPClient_Send( const TransportInterface_t * pTransport,
  * This will return the location of the response header value in the
  * #HTTPResponse_t.pBuffer buffer.
  *
+ * The location within #HTTPResponse_t.pBuffer, of the value found, will be
+ * returned in @p pValue. If the value empty, for the @p pField found, then this
+ * function will return #HTTPSuccess and @p pValue will be set to NULL with
+ * @p pValueLen set to zero. According to rfc2616 it is not invalid to have an
+ * empty value for some header fields.
+ *
  * @note This function should only be called on a complete HTTP response. If the
  * request is sent through the #HTTPClient_Send function, the #HTTPResponse_t is
  * incomplete until #HTTPClient_Send returns.

--- a/source/include/core_http_client.h
+++ b/source/include/core_http_client.h
@@ -799,10 +799,10 @@ HTTPStatus_t HTTPClient_Send( const TransportInterface_t * pTransport,
  * #HTTPResponse_t.pBuffer buffer.
  *
  * The location, within #HTTPResponse_t.pBuffer, of the value found, will be
- * returned in @p pValue. If the header value is empty for the found @p pField, then
- * this function will return #HTTPSuccess, and set the values for @p pValue and @pValueLen 
- * as NULL and zero respectively. According to RFC 2616, it is not invalid to have an
- * empty value for some header fields.
+ * returned in @p pValue. If the header value is empty for the found @p pField,
+ * then this function will return #HTTPSuccess, and set the values for @p pValue
+ * and @p ValueLen as NULL and zero respectively. According to RFC 2616, it is not
+ * invalid to have an empty value for some header fields.
  *
  * @note This function should only be called on a complete HTTP response. If the
  * request is sent through the #HTTPClient_Send function, the #HTTPResponse_t is

--- a/source/include/core_http_client.h
+++ b/source/include/core_http_client.h
@@ -800,9 +800,9 @@ HTTPStatus_t HTTPClient_Send( const TransportInterface_t * pTransport,
  *
  * The location, within #HTTPResponse_t.pBuffer, of the value found, will be
  * returned in @p pValue. If the header value is empty for the found @p pField,
- * then this function will return #HTTPSuccess, and set the values for @p pValue
- * and @p ValueLen as NULL and zero respectively. According to RFC 2616, it is not
- * invalid to have an empty value for some header fields.
+ * then this function will return #HTTPSuccess, and set the values for
+ * @p pValueLoc and @p pValueLen as NULL and zero respectively. According to
+ * RFC 2616, it is not invalid to have an empty value for some header fields.
  *
  * @note This function should only be called on a complete HTTP response. If the
  * request is sent through the #HTTPClient_Send function, the #HTTPResponse_t is

--- a/source/include/core_http_client.h
+++ b/source/include/core_http_client.h
@@ -799,9 +799,9 @@ HTTPStatus_t HTTPClient_Send( const TransportInterface_t * pTransport,
  * #HTTPResponse_t.pBuffer buffer.
  *
  * The location, within #HTTPResponse_t.pBuffer, of the value found, will be
- * returned in @p pValue. If the value is empty, for the @p pField found, then
- * this function will return #HTTPSuccess and @p pValue will be set to NULL with
- * @p pValueLen set to zero. According to RFC 2616 it is not invalid to have an
+ * returned in @p pValue. If the header value is empty for the found @p pField, then
+ * this function will return #HTTPSuccess, and set the values for @p pValue and @pValueLen 
+ * as NULL and zero respectively. According to RFC 2616, it is not invalid to have an
  * empty value for some header fields.
  *
  * @note This function should only be called on a complete HTTP response. If the

--- a/source/include/core_http_client.h
+++ b/source/include/core_http_client.h
@@ -801,7 +801,7 @@ HTTPStatus_t HTTPClient_Send( const TransportInterface_t * pTransport,
  * The location within #HTTPResponse_t.pBuffer, of the value found, will be
  * returned in @p pValue. If the value empty, for the @p pField found, then this
  * function will return #HTTPSuccess and @p pValue will be set to NULL with
- * @p pValueLen set to zero. According to rfc2616 it is not invalid to have an
+ * @p pValueLen set to zero. According to RFC 2616 it is not invalid to have an
  * empty value for some header fields.
  *
  * @note This function should only be called on a complete HTTP response. If the

--- a/test/unit-test/core_http_utest.c
+++ b/test/unit-test/core_http_utest.c
@@ -1393,7 +1393,7 @@ void test_Http_ReadHeader_Happy_Path()
 
 /**
  * @brief Test the case when the header is empty. Empty headers are not
- * invalid according to rfc2616.
+ * invalid according to RFC 2616.
  */
 void test_Http_ReadHeader_EmptyHeaderValue()
 {

--- a/test/unit-test/core_http_utest.c
+++ b/test/unit-test/core_http_utest.c
@@ -1405,7 +1405,7 @@ void test_Http_ReadHeader_EmptyHeaderValue()
     expectedValCbRetVal = HTTP_PARSER_STOP_PARSING;
     pFieldLocToReturn = &pTestResponseEmptyValue[ headerFieldInRespLoc ];
     fieldLenToReturn = headerFieldInRespLen;
-    /* Add two charactesr past the empty value to point to the next field. */
+    /* Add two characters past the empty value to point to the next field. */
     pValueLocToReturn = &pTestResponseEmptyValue[ headerValInRespLoc + HTTP_HEADER_LINE_SEPARATOR_LEN ];
     /* http-parser will pass in a value of zero for an empty value. */
     valueLenToReturn = 0;

--- a/test/unit-test/core_http_utest.c
+++ b/test/unit-test/core_http_utest.c
@@ -141,6 +141,15 @@ static const char * pTestResponse = "HTTP/1.1 200 OK\r\n"
                                     "header_not_in_buffer: test-value3\r\n"
                                     "\r\n";
 
+/* HTTP response for testing HTTPClient_ReadHeader API. This response contains
+ * an empty value. */
+static const char * pTestResponseEmptyValue = "HTTP/1.1 200 OK\r\n"
+                                              "test-header0: test-value0\r\n"
+                                              "test-header1: \r\n"
+                                              "test-header2: test-value2\r\n"
+                                              "\r\n";
+
+
 #define HEADER_INVALID_PARAMS        "Header"
 #define HEADER_INVALID_PARAMS_LEN    ( sizeof( HEADER_INVALID_PARAMS ) - 1 )
 
@@ -1380,6 +1389,40 @@ void test_Http_ReadHeader_Happy_Path()
     TEST_ASSERT_EQUAL( HTTPSuccess, retCode );
     TEST_ASSERT_EQUAL( &pTestResponse[ headerValInRespLoc ], pValueLoc );
     TEST_ASSERT_EQUAL( headerValInRespLen, valueLen );
+}
+
+/**
+ * @brief Test the case when the header is empty. Empty headers are not
+ * invalid according to rfc2616.
+ */
+void test_Http_ReadHeader_EmptyHeaderValue()
+{
+    /* Add expectations for http_parser init dependencies. */
+    http_parser_init_ExpectAnyArgs();
+    http_parser_settings_init_ExpectAnyArgs();
+
+    /* Configure the http_parser_execute mock. */
+    expectedValCbRetVal = HTTP_PARSER_STOP_PARSING;
+    pFieldLocToReturn = &pTestResponseEmptyValue[ headerFieldInRespLoc ];
+    fieldLenToReturn = headerFieldInRespLen;
+    /* Add two charactesr past the empty value to point to the next field. */
+    pValueLocToReturn = &pTestResponseEmptyValue[ headerValInRespLoc + HTTP_HEADER_LINE_SEPARATOR_LEN ];
+    /* http-parser will pass in a value of zero for an empty value. */
+    valueLenToReturn = 0;
+    invokeHeaderFieldCallback = 1u;
+    invokeHeaderValueCallback = 1u;
+    parserErrNo = HPE_CB_header_value;
+    http_parser_execute_ExpectAnyArgsAndReturn( strlen( pTestResponse ) );
+
+    /* Call the function under test. */
+    retCode = HTTPClient_ReadHeader( &testResponse,
+                                     HEADER_IN_BUFFER,
+                                     HEADER_IN_BUFFER_LEN,
+                                     &pValueLoc,
+                                     &valueLen );
+    TEST_ASSERT_EQUAL( HTTPSuccess, retCode );
+    TEST_ASSERT_EQUAL( NULL, pValueLoc );
+    TEST_ASSERT_EQUAL( 0, valueLen );
 }
 
 /**


### PR DESCRIPTION
According to rfc 2616 It is not invalid to have an empty value for some header field.

http-parser will invoke the onHeaderValue callback with a length of zero when the header value is empty for a header field.

This commit updates the HTTPClient_ReadHeader function to return success if the header field is found, but the header value happens to be empty.