### PR TITLE
Disable default cloning support of CMock and CBMC submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,15 @@
 [submodule "test/cbmc/aws-templates-for-cbmc-proofs"]
 	path = test/cbmc/aws-templates-for-cbmc-proofs
 	url = https://github.com/awslabs/aws-templates-for-cbmc-proofs.git
+	update = none
 [submodule "test/unit-test/CMock"]
 	path = test/unit-test/CMock
 	url = https://github.com/ThrowTheSwitch/CMock.git
+	update = none
 [submodule "test/cbmc/litani"]
 	path = test/cbmc/litani
 	url = https://github.com/awslabs/aws-build-accumulator
+	update = none
 [submodule "source/dependency/3rdparty/http_parser"]
 	path = source/dependency/3rdparty/http_parser
 	url = https://github.com/nodejs/http-parser.git

--- a/test/unit-test/cmock_build.cmake
+++ b/test/unit-test/cmock_build.cmake
@@ -3,7 +3,7 @@ macro( clone_cmock )
         find_package( Git REQUIRED )
         message( "Cloning submodule CMock." )
         execute_process( COMMAND rm -rf ${CMOCK_DIR}
-                         COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive ${CMOCK_DIR}
+                         COMMAND ${GIT_EXECUTABLE} submodule update --checkout --init --recursive ${CMOCK_DIR}
                         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
                         RESULT_VARIABLE CMOCK_CLONE_RESULT )
 


### PR DESCRIPTION
Disable submodule cloning of **CMock** and **CBMC** submodules with the `git submodule update` command to improve cloning experience of the `aws/aws-iot-device-sdk-for-embedded-c` repository that submodules this repository. The pupose is to avoid duplicate cloning of leaf submodules from multiple repositories submoduled by C-SDK