### PR TITLE
Add README.md link to memory estimates doxygen page

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ score over 8. This library has also undergone both static code analysis from
 safety and data structure invariance through the
 [CBMC automated reasoning tool](https://www.cprover.org/cbmc/).
 
+See memory requirements for this library [here](https://docs.aws.amazon.com/embedded-csdk/202011.00/lib-ref/libraries/standard/coreHTTP/docs/doxygen/output/html/index.html#http_memory_requirements).
+
 ## coreHTTP Config File
 
 The HTTP client library exposes configuration macros that are required for


### PR DESCRIPTION
Adding link in README to point to the library-specific doxygen page for memory estimates. Draft until doxygen links are live.