### PR TITLE
Add configurable code to flush the network socket upon error.

### DIFF
--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -277,6 +277,9 @@ defined.
 @section HTTP_USER_AGENT_VALUE
 @copydoc HTTP_USER_AGENT_VALUE
 
+@section HTTP_FLUSH_NETWORK_SOCKET_ON_ERROR
+@copydoc HTTP_FLUSH_NETWORK_SOCKET_ON_ERROR
+
 @section http_logerror LogError
 @copydoc LogError
 

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -30,6 +30,7 @@ copybrief
 corehttp
 coverity
 cprover
+currentreceived
 datalen
 datelen
 defgroup

--- a/source/core_http_client.c
+++ b/source/core_http_client.c
@@ -2037,7 +2037,7 @@ static HTTPStatus_t receiveAndParseHttpResponse( const TransportInterface_t * pT
                                           &currentReceived );
             }
         }
-    #endif /* ifdef HTTP_FLUSH_NETWORK_SOCKET_ON_ERROR */
+    #endif /* if ( HTTP_FLUSH_NETWORK_SOCKET_ON_ERROR == 1U ) */
 
     return returnStatus;
 }

--- a/source/include/core_http_client.h
+++ b/source/include/core_http_client.h
@@ -700,6 +700,8 @@ HTTPStatus_t HTTPClient_AddRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
  * body in @p pRequestBodyBuf over the transport. The response is received in
  * #HTTPResponse_t.pBuffer.
  *
+ * If this function returns an error any data in @p pResponse is invalid.
+ *
  * If #HTTP_SEND_DISABLE_CONTENT_LENGTH_FLAG is not set in parameter @p sendFlags,
  * then the Content-Length to be sent to the server is automatically written to
  * @p pRequestHeaders. The Content-Length will not be written when there is
@@ -707,6 +709,12 @@ HTTPStatus_t HTTPClient_AddRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
  * Content-Length then #HTTPInsufficientMemory is returned. Please see
  * #HTTP_MAX_CONTENT_LENGTH_HEADER_LENGTH for the maximum Content-Length header
  * field and value that could be written to the buffer.
+ *
+ * By default HTTP_FLUSH_NETWORK_SOCKET_ON_ERROR is set to 1. Therefore, upon
+ * any error in parsing the response, the network socket is flushed using the
+ * user implemented #TransportRecv_t function in @p pTransport and the user
+ * configured #HTTPResponse_t.pBuffer. Set HTTP_FLUSH_NETWORK_SOCKET_ON_ERROR to
+ * 0 to skip flushing the network socket on error.
  *
  * The application should close the connection with the server if any of the
  * following errors are returned:

--- a/source/include/core_http_config_defaults.h
+++ b/source/include/core_http_config_defaults.h
@@ -65,6 +65,17 @@
 #endif
 
 /**
+ * @brief When set to 1U, the network socket will be flushed after an error
+ * occurs during response parsing.
+ *
+ * <b>Possible values:</b> 1U or 0U.<br>
+ * <b>Default value:</b> 1U
+ */
+#ifndef HTTP_FLUSH_NETWORK_SOCKET_ON_ERROR
+    #define HTTP_FLUSH_NETWORK_SOCKET_ON_ERROR    1U
+#endif
+
+/**
  * @brief Macro that is called in the HTTP Client library for logging "Error" level
  * messages.
  *


### PR DESCRIPTION
Flush the network socket upon error when configurable macro HTTP_FLUSH_NETWORK_SOCKET_ON_ERROR is set to 1U.
Use the user HTTPResponse_t.pBuffer to flush the network socket.

If the there are too many headers in the response, the response cannot fit in the configured pResponse->pBuffer, or an error occurred during parsing, then there could be data left on the socket. If the application desires continuing to use same connection after an error is returned, the socket needs to be flushed of older data.