### PR TITLE
Automate release with GitHub Action job

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -1,0 +1,114 @@
+name: Release automation
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit_id:
+        description: 'Commit ID to tag and create a release for'
+        required: true
+      version_number:
+        description: 'Release Version Number (Eg, v1.0.0)'
+        required: true
+
+jobs:
+  tag-commit:
+    name: Tag commit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.commit_id }}
+      - name: Configure git identity
+        run: |
+            git config --global user.name "Release Workflow"
+      - name: Tag Commit and Push to remote
+        run: |
+          git tag ${{ github.event.inputs.version_number }} -a -m "coreHTTP Library ${{ github.event.inputs.version_number }}"
+          git push origin --tags
+      - name: Verify tag on remote
+        run: |
+          git tag -d ${{ github.event.inputs.version_number }}
+          git remote update
+          git checkout tags/${{ github.event.inputs.version_number }}
+          git diff origin/${{ github.event.inputs.commit_id }} tags/${{ github.event.inputs.version_number }}
+  create-zip:
+    needs: tag-commit
+    name: Create ZIP and verify package for release asset.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install ZIP tools
+        run: sudo apt-get install zip unzip
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.commit_id }}
+          path: coreHTTP
+          submodules: recursive
+      - name: Checkout disabled submodules
+        run: |
+          cd coreHTTP
+          git submodule update --init --checkout --recursive
+      - name: Create ZIP
+        run: |
+          zip -r coreHTTP-${{ github.event.inputs.version_number }}.zip coreHTTP -x "*.git*"
+          ls ./
+      - name: Validate created ZIP
+        run: |
+          mkdir zip-check
+          mv coreHTTP-${{ github.event.inputs.version_number }}.zip zip-check
+          cd zip-check
+          unzip coreHTTP-${{ github.event.inputs.version_number }}.zip -d coreHTTP-${{ github.event.inputs.version_number }}
+          ls coreHTTP-${{ github.event.inputs.version_number }}
+          diff -r -x "*.git*" coreHTTP-${{ github.event.inputs.version_number }}/coreHTTP/ ../coreHTTP/
+          cd ../
+      - name: Build
+        run: |
+          cd zip-check/coreHTTP-${{ github.event.inputs.version_number }}/coreHTTP
+          sudo apt-get install -y lcov
+          cmake -S test -B build/ \
+          -G "Unix Makefiles" \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -DBUILD_CLONE_SUBMODULES=ON \
+          -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG'
+          make -C build/ all
+      - name: Test
+        run: |
+          cd zip-check/coreHTTP-${{ github.event.inputs.version_number }}/coreHTTP/build/
+          ctest -E system --output-on-failure
+          cd ..
+      - name: Create artifact of ZIP
+        uses: actions/upload-artifact@v2
+        with:
+          name: coreHTTP-${{ github.event.inputs.version_number }}.zip
+          path: zip-check/coreHTTP-${{ github.event.inputs.version_number }}.zip
+  create-release:
+    needs: create-zip
+    name: Create Release and Upload Release Asset
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.event.inputs.version_number }}
+          release_name: ${{ github.event.inputs.version_number }}
+          body: Release ${{ github.event.inputs.version_number }} of the coreHTTP Library.
+          draft: false
+          prerelease: false
+      - name: Download ZIP artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: coreHTTP-${{ github.event.inputs.version_number }}.zip
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./coreHTTP-${{ github.event.inputs.version_number }}.zip
+          asset_name: coreHTTP-${{ github.event.inputs.version_number }}.zip
+          asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           git tag -d ${{ github.event.inputs.version_number }}
           git remote update
           git checkout tags/${{ github.event.inputs.version_number }}
-          git diff origin/${{ github.event.inputs.commit_id }} tags/${{ github.event.inputs.version_number }}
+          git diff ${{ github.event.inputs.commit_id }} tags/${{ github.event.inputs.version_number }}
   create-zip:
     needs: tag-commit
     name: Create ZIP and verify package for release asset.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,8 +69,7 @@ jobs:
           cmake -S test -B build/ \
           -G "Unix Makefiles" \
           -DCMAKE_BUILD_TYPE=Debug \
-          -DBUILD_CLONE_SUBMODULES=ON \
-          -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG'
+          -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -DNDEBUG'
           make -C build/ all
       - name: Test
         run: |

--- a/source/interface/transport_interface.h
+++ b/source/interface/transport_interface.h
@@ -1,5 +1,5 @@
 /*
- * coreMQTT v1.0.1
+ * coreHTTP v1.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/source/interface/transport_interface.h
+++ b/source/interface/transport_interface.h
@@ -1,5 +1,5 @@
 /*
- * coreHTTP v1.0.0
+ * coreMQTT v1.0.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -163,7 +163,11 @@ typedef struct NetworkContext NetworkContext_t;
  * @param[in] pBuffer Buffer to receive the data into.
  * @param[in] bytesToRecv Number of bytes requested from the network.
  *
- * @return The number of bytes received or a negative error code.
+ * @return The number of bytes received or a negative value to indicate
+ * error.
+ * @note If no data is available on the network to read and no error
+ * has occurred, zero MUST be the return value. Zero MUST NOT be used
+ * if a network disconnection has occurred.
  */
 /* @[define_transportrecv] */
 typedef int32_t ( * TransportRecv_t )( NetworkContext_t * pNetworkContext,


### PR DESCRIPTION
**Add a GitHub Action job to trigger a release process** which includes operations of: 
1. Creating and pushing the release tag to the repository 
2. Verifying the pushed tag (performing a diff with the commit ID which is tagged) 
3. Creating a ZIP for the release asset. 
4. Verifying the ZIP by performing a diff check and running unit tests on the unzipped files. 5. Creating a release on the repository for the tag, and uploading the ZIP as the release asset

The workflow can be manually triggered and takes the input values of **Commit ID** (to create a release for) and the **Version string** for tagging the release with

**Testing**
Here is an example run of the release job on my fork repository: 
https://github.com/aggarw13/coreHTTP/runs/1512507665?check_suite_focus=true
It pushed the test tag (`test-v2`) and created a release along with the release asset on the repository: https://github.com/aggarw13/coreHTTP/releases/tag/test-v3