### PR TITLE
Implement transport send and receive timeouts in coreHTTP

### DIFF
--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -191,6 +191,8 @@ then the @ref HTTP_DO_NOT_USE_CUSTOM_CONFIG macro must be defined.
 The following macros can be configured for this library:
  - @ref HTTP_MAX_RESPONSE_HEADERS_SIZE_BYTES
  - @ref HTTP_USER_AGENT_VALUE
+ - @ref HTTP_SEND_RETRY_TIMEOUT_MS
+ - @ref HTTP_RECV_RETRY_TIMEOUT_MS
 
 In addition, the following logging macros are used throughout this library:
  - @ref LogError
@@ -232,6 +234,21 @@ struct NetworkContext {
     // Fields necessary for the transport implementations, e.g. a TCP socket descriptor.
 };
 @endcode
+
+@section http_porting_time Time Function
+@brief The HTTP library optionally relies on a function to generate millisecond
+timestamps, for the purpose of calculating the elapsed time between non-zero
+network sends and receives.
+
+@see @ref HTTPClient_GetCurrentTimeFunc_t
+
+Platforms can supply a function capable of generating 32-bit timestamps of
+millisecond resolution. These timestamps need not correspond with any real world
+clock; the only requirement is that the difference between two timestamps must
+be an accurate representation of the duration between them, in milliseconds.
+
+This function is used in conjunction with macros @ref HTTP_SEND_RETRY_TIMEOUT_MS
+and @ref HTTP_RECV_RETRY_TIMEOUT_MS.
 */
 
 /**

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -237,15 +237,16 @@ struct NetworkContext {
 
 @section http_porting_time Time Function
 @brief The HTTP library optionally relies on a function to generate millisecond
-timestamps, for the purpose of calculating the elapsed time between non-zero
-network sends and receives.
+timestamps, for the purpose of calculating the elapsed time when no data has
+been sent or received.
 
 @see @ref HTTPClient_GetCurrentTimeFunc_t
 
-Platforms can supply a function capable of generating 32-bit timestamps of
-millisecond resolution. These timestamps need not correspond with any real world
-clock; the only requirement is that the difference between two timestamps must
-be an accurate representation of the duration between them, in milliseconds.
+Applications can supply their platform-specific function capable of generating
+32-bit timestamps of millisecond resolution. These timestamps need not correspond
+with any real world clock; the only requirement is that the difference between two
+timestamps must be an accurate representation of the duration between them, in
+milliseconds.
 
 This function is used in conjunction with macros @ref HTTP_SEND_RETRY_TIMEOUT_MS
 and @ref HTTP_RECV_RETRY_TIMEOUT_MS.

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -277,6 +277,12 @@ defined.
 @section HTTP_USER_AGENT_VALUE
 @copydoc HTTP_USER_AGENT_VALUE
 
+@section HTTP_SEND_RETRY_TIMEOUT_MS
+@copydoc HTTP_SEND_RETRY_TIMEOUT_MS
+
+@section HTTP_RECV_RETRY_TIMEOUT_MS
+@copydoc HTTP_RECV_RETRY_TIMEOUT_MS
+
 @section http_logerror LogError
 @copydoc LogError
 

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -9,7 +9,6 @@ api
 apis
 ascii
 aws
-bool
 br
 bufferlen
 bufferlength
@@ -18,7 +17,6 @@ bytesremaining
 bytessent
 bytestorecv
 bytestosend
-calltlsrecvfunc
 cb
 cbmc
 chk
@@ -231,7 +229,6 @@ tcpsocketcontext
 tls
 tlscontext
 tlsrecv
-tlsrecvcount
 tlssend
 toascii
 totalreceived

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -9,6 +9,7 @@ api
 apis
 ascii
 aws
+bool
 br
 bufferlen
 bufferlength
@@ -17,6 +18,7 @@ bytesremaining
 bytessent
 bytestorecv
 bytestosend
+calltlsrecvfunc
 cb
 cbmc
 chk
@@ -52,6 +54,8 @@ findheaderonheadercompletecallback
 findheadervalueparsercallback
 firstpartbytes
 getfinalresponsestatus
+gettime
+gettimestampms
 github
 headercount
 headerslen
@@ -211,6 +215,8 @@ rfc
 sdk
 senderrorcall
 sendflags
+sendhttpbody
+sendhttpheaders
 sendpartialcall
 sizeof
 snprintf
@@ -225,6 +231,7 @@ tcpsocketcontext
 tls
 tlscontext
 tlsrecv
+tlsrecvcount
 tlssend
 toascii
 totalreceived

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -201,6 +201,7 @@ receivehttpdata
 recv
 recvcurrentcall
 recvstopcall
+recvtimeoutcall
 reponse
 reqbodybuflen
 reqbodylen

--- a/source/core_http_client.c
+++ b/source/core_http_client.c
@@ -1786,7 +1786,7 @@ static HTTPStatus_t sendHttpData( const TransportInterface_t * pTransport,
             /* It is a bug in the application's transport send implementation if
              * more bytes than expected are sent. To avoid a possible overflow
              * in converting bytesRemaining from unsigned to signed, this assert
-             * must exist after the check for transportStatus being negative. */
+             * must exist after the check for bytesSent being negative. */
             assert( ( size_t ) bytesSent <= bytesRemaining );
 
             /* Record the most recent time of successful transmission. */
@@ -2002,7 +2002,7 @@ static HTTPStatus_t receiveAndParseHttpResponse( const TransportInterface_t * pT
         {
             LogError( ( "Failed to receive HTTP data: Transport recv() "
                         "returned error: TransportStatus=%ld",
-                        ( long int ) transportStatus ) );
+                        ( long int ) currentReceived ) );
             returnStatus = HTTPNetworkError;
 
             /* Do not invoke the parser on network errors. */

--- a/source/core_http_client.c
+++ b/source/core_http_client.c
@@ -1762,7 +1762,7 @@ static HTTPStatus_t sendHttpData( const TransportInterface_t * pTransport,
         retryTimeoutMs = 0U;
     }
 
-    /* Record the most recent time of successful transmission. */
+    /* Start the last send time to allow retries on the first zero data sent. */
     lastSendTimeMs = getTimestampMs();
 
     /* Loop until all data is sent. */
@@ -2180,9 +2180,13 @@ HTTPStatus_t HTTPClient_Send( const TransportInterface_t * pTransport,
     }
     else
     {
-        /* Set a zero timestamp function when the application did not configure
-         * one. */
-        pResponse->getTime = getZeroTimestampMs;
+        if( pResponse->getTime == NULL )
+        {
+            /* Set a zero timestamp function when the application did not configure
+             * one. */
+            pResponse->getTime = getZeroTimestampMs;
+        }
+
         returnStatus = HTTPSuccess;
     }
 
@@ -2198,8 +2202,6 @@ HTTPStatus_t HTTPClient_Send( const TransportInterface_t * pTransport,
 
     if( returnStatus == HTTPSuccess )
     {
-        /* If the application chooses to receive a response, then pResponse
-         * will not be NULL. */
         returnStatus = receiveAndParseHttpResponse( pTransport,
                                                     pResponse,
                                                     pRequestHeaders );

--- a/source/include/core_http_client.h
+++ b/source/include/core_http_client.h
@@ -454,12 +454,13 @@ typedef struct HTTPResponse
     /**
      * @brief Optional callback for getting the system time.
      *
-     * This is used to calculate the elapsed time between network sends and
-     * receives greater than zero. If this field is set to NULL, then network
-     * send and receive won't be retries after a zero is returned.
+     * This is used to calculate the elapsed time when retrying network reads or
+     * sends that return zero bytes received or sent, respectively. If this
+     * field is set to NULL, then network send and receive won't be retried
+     * after a zero is returned.
      *
-     * If this function is set, then the maximum elapsed time between network
-     * receives greater than zero is set in HTTP_RECV_RETRY_TIMEOUT_MS.
+     * If this function is set, then the maximum time for retrying network reads
+     * that return zero bytes can be set through #HTTP_RECV_RETRY_TIMEOUT_MS.
      *
      * If this function is set, then the maximum elapsed time between network
      * sends greater than zero is set in HTTP_SEND_RETRY_TIMEOUT_MS.

--- a/source/include/core_http_client.h
+++ b/source/include/core_http_client.h
@@ -412,6 +412,15 @@ typedef struct HTTPClient_ResponseHeaderParsingCallback
 } HTTPClient_ResponseHeaderParsingCallback_t;
 
 /**
+ * @ingroup http_callback_types
+ * @brief Application provided function to query the current time in
+ * milliseconds.
+ *
+ * @return The current time in milliseconds.
+ */
+typedef uint32_t (* HTTPClient_GetCurrentTimeFunc_t )( void );
+
+/**
  * @ingroup http_struct_types
  * @brief Represents an HTTP response.
  */
@@ -441,6 +450,21 @@ typedef struct HTTPResponse
      * Set to NULL to disable.
      */
     HTTPClient_ResponseHeaderParsingCallback_t * pHeaderParsingCallback;
+
+    /**
+     * @brief Optional callback for getting the system time.
+     * 
+     * This is used to calculate the elapsed time between network sends and
+     * receives greater than zero. If this field is set to NULL, then network
+     * send and receive won't be retries after a zero is returned.
+     *
+     * If this function is set, then the maximum elapsed time between network
+     * receives greater than zero is set in HTTP_RECV_RETRY_TIMEOUT_MS.
+     * 
+     * If this function is set, then the maximum elapsed time between network
+     * sends greater than zero is set in HTTP_SEND_RETRY_TIMEOUT_MS.
+     */
+    HTTPClient_GetCurrentTimeFunc_t * pGetTimeFunction;
 
     /**
      * @brief The starting location of the response headers in pBuffer.

--- a/source/include/core_http_client.h
+++ b/source/include/core_http_client.h
@@ -453,18 +453,18 @@ typedef struct HTTPResponse
 
     /**
      * @brief Optional callback for getting the system time.
-     * 
+     *
      * This is used to calculate the elapsed time between network sends and
      * receives greater than zero. If this field is set to NULL, then network
      * send and receive won't be retries after a zero is returned.
      *
      * If this function is set, then the maximum elapsed time between network
      * receives greater than zero is set in HTTP_RECV_RETRY_TIMEOUT_MS.
-     * 
+     *
      * If this function is set, then the maximum elapsed time between network
      * sends greater than zero is set in HTTP_SEND_RETRY_TIMEOUT_MS.
      */
-    HTTPClient_GetCurrentTimeFunc_t * pGetTimeFunction;
+    HTTPClient_GetCurrentTimeFunc_t getTime;
 
     /**
      * @brief The starting location of the response headers in pBuffer.

--- a/source/include/core_http_config_defaults.h
+++ b/source/include/core_http_config_defaults.h
@@ -75,6 +75,10 @@
  *
  * If the timeout expires, the #HTTPClient_Send function will return
  * #HTTPNetworkError.
+ * 
+ * If #HTTPResponse_t.getTime is set to NULL, then this HTTP_RECV_RETRY_TIMEOUT_MS
+ * is unused. When this timeout is unused, #HTTPClient_Send will not retry the
+ * transport receive when it returns zero.
  *
  * <b>Possible values:</b> Any positive 32 bit integer. A small timeout value
  * is recommended. <br>
@@ -94,6 +98,10 @@
  * transmission over the network through the transport send function.
  *
  * If the timeout expires, the #HTTPClient_Send function returns #HTTPNetworkError.
+ * 
+ * If #HTTPResponse_t.getTime is set to NULL, then this HTTP_RECV_RETRY_TIMEOUT_MS
+ * is unused. When this timeout is unused, #HTTPClient_Send will not retry the
+ * transport send when it returns zero.
  *
  * <b>Possible values:</b> Any positive 32 bit integer. A small timeout value
  * is recommended. <br>

--- a/source/include/core_http_config_defaults.h
+++ b/source/include/core_http_config_defaults.h
@@ -78,7 +78,7 @@
  *
  * If #HTTPResponse_t.getTime is set to NULL, then this HTTP_RECV_RETRY_TIMEOUT_MS
  * is unused. When this timeout is unused, #HTTPClient_Send will not retry the
- * transport receive when it returns zero.
+ * transport receive calls that return zero bytes read.
  *
  * <b>Possible values:</b> Any positive 32 bit integer. A small timeout value
  * is recommended. <br>
@@ -101,7 +101,7 @@
  *
  * If #HTTPResponse_t.getTime is set to NULL, then this HTTP_RECV_RETRY_TIMEOUT_MS
  * is unused. When this timeout is unused, #HTTPClient_Send will not retry the
- * transport send when it returns zero.
+ * transport send calls that return zero bytes sent.
  *
  * <b>Possible values:</b> Any positive 32 bit integer. A small timeout value
  * is recommended. <br>

--- a/source/include/core_http_config_defaults.h
+++ b/source/include/core_http_config_defaults.h
@@ -65,6 +65,45 @@
 #endif
 
 /**
+ * @brief The maximum duration between non-empty network reads while receiving
+ * an HTTP response via the #HTTPClient_Send API function.
+ * 
+ * When an incoming HTTP response is detected, the transport receive function
+ * may be called multiple times until the end of the response is detected by the
+ * parser. This timeout represents the maximum duration that is allowed without
+ * any data reception from the network for the incoming response.
+ * 
+ * If the timeout expires, the #HTTPClient_Send function will return
+ * #HTTPNetworkError.
+ * 
+ * <b>Possible values:</b> Any positive 32 bit integer. A small timeout value
+ * is recommended. <br>
+ * <b>Default value:</b> `10`
+ */
+#ifndef HTTP_RECV_RETRY_TIMEOUT_MS
+    #define HTTP_RECV_RETRY_TIMEOUT_MS    ( 10U )
+#endif
+
+/**
+ * @brief The maximum duration between non-empty network transmissions while
+ * sending an HTTP request via the #HTTPClient_Send API function.
+ *
+ * When sending an HTTP request, the transport send function may be called multiple
+ * times until all of the required number of bytes are sent.
+ * This timeout represents the maximum duration that is allowed for no data
+ * transmission over the network through the transport send function.
+ *
+ * If the timeout expires, the #HTTPClient_Send function returns #HTTPNetworkError.
+ *
+ * <b>Possible values:</b> Any positive 32 bit integer. A small timeout value
+ * is recommended. <br>
+ * <b>Default value:</b> `10`
+ */
+#ifndef HTTP_SEND_RETRY_TIMEOUT_MS
+    #define HTTP_SEND_RETRY_TIMEOUT_MS    ( 10U )
+#endif
+
+/**
  * @brief Macro that is called in the HTTP Client library for logging "Error" level
  * messages.
  *

--- a/source/include/core_http_config_defaults.h
+++ b/source/include/core_http_config_defaults.h
@@ -75,7 +75,7 @@
  *
  * If the timeout expires, the #HTTPClient_Send function will return
  * #HTTPNetworkError.
- * 
+ *
  * If #HTTPResponse_t.getTime is set to NULL, then this HTTP_RECV_RETRY_TIMEOUT_MS
  * is unused. When this timeout is unused, #HTTPClient_Send will not retry the
  * transport receive when it returns zero.
@@ -98,7 +98,7 @@
  * transmission over the network through the transport send function.
  *
  * If the timeout expires, the #HTTPClient_Send function returns #HTTPNetworkError.
- * 
+ *
  * If #HTTPResponse_t.getTime is set to NULL, then this HTTP_RECV_RETRY_TIMEOUT_MS
  * is unused. When this timeout is unused, #HTTPClient_Send will not retry the
  * transport send when it returns zero.

--- a/source/include/core_http_config_defaults.h
+++ b/source/include/core_http_config_defaults.h
@@ -78,10 +78,10 @@
  *
  * <b>Possible values:</b> Any positive 32 bit integer. A small timeout value
  * is recommended. <br>
- * <b>Default value:</b> `0`
+ * <b>Default value:</b> `10`
  */
 #ifndef HTTP_RECV_RETRY_TIMEOUT_MS
-    #define HTTP_RECV_RETRY_TIMEOUT_MS    ( 0U )
+    #define HTTP_RECV_RETRY_TIMEOUT_MS    ( 10U )
 #endif
 
 /**
@@ -97,10 +97,10 @@
  *
  * <b>Possible values:</b> Any positive 32 bit integer. A small timeout value
  * is recommended. <br>
- * <b>Default value:</b> `0`
+ * <b>Default value:</b> `10`
  */
 #ifndef HTTP_SEND_RETRY_TIMEOUT_MS
-    #define HTTP_SEND_RETRY_TIMEOUT_MS    ( 0U )
+    #define HTTP_SEND_RETRY_TIMEOUT_MS    ( 10U )
 #endif
 
 /**

--- a/source/include/core_http_config_defaults.h
+++ b/source/include/core_http_config_defaults.h
@@ -67,21 +67,21 @@
 /**
  * @brief The maximum duration between non-empty network reads while receiving
  * an HTTP response via the #HTTPClient_Send API function.
- * 
- * When an incoming HTTP response is detected, the transport receive function
- * may be called multiple times until the end of the response is detected by the
- * parser. This timeout represents the maximum duration that is allowed without
- * any data reception from the network for the incoming response.
- * 
+ *
+ * The transport receive function may be called multiple times until the end of
+ * the response is detected by the parser. This timeout represents the maximum
+ * duration that is allowed without any data reception from the network for the
+ * incoming response.
+ *
  * If the timeout expires, the #HTTPClient_Send function will return
  * #HTTPNetworkError.
- * 
+ *
  * <b>Possible values:</b> Any positive 32 bit integer. A small timeout value
  * is recommended. <br>
- * <b>Default value:</b> `10`
+ * <b>Default value:</b> `0`
  */
 #ifndef HTTP_RECV_RETRY_TIMEOUT_MS
-    #define HTTP_RECV_RETRY_TIMEOUT_MS    ( 10U )
+    #define HTTP_RECV_RETRY_TIMEOUT_MS    ( 0U )
 #endif
 
 /**
@@ -97,10 +97,10 @@
  *
  * <b>Possible values:</b> Any positive 32 bit integer. A small timeout value
  * is recommended. <br>
- * <b>Default value:</b> `10`
+ * <b>Default value:</b> `0`
  */
 #ifndef HTTP_SEND_RETRY_TIMEOUT_MS
-    #define HTTP_SEND_RETRY_TIMEOUT_MS    ( 10U )
+    #define HTTP_SEND_RETRY_TIMEOUT_MS    ( 0U )
 #endif
 
 /**

--- a/source/interface/transport_interface.h
+++ b/source/interface/transport_interface.h
@@ -96,37 +96,16 @@
  *                                      size_t bytesToRecv )
  * {
  *     int32_t bytesReceived = 0;
- *     bool callTlsRecvFunc = true;
- *
- *     // For a single byte read request, check if data is available on the network.
- *     if( bytesToRecv == 1 )
+ *     bytesReceived = TLSRecv( pNetworkContext->tlsContext,
+ *                              pBuffer,
+ *                              bytesToRecv,
+ *                              MY_SOCKET_TIMEOUT );
+ *     if( bytesReceived < 0 )
  *     {
- *        // If no data is available on the network, do not call TLSRecv
- *        // to avoid blocking for socket timeout.
- *        if( TLSRecvCount( pNetworkContext->tlsContext ) == 0 )
- *        {
- *            callTlsRecvFunc = false;
- *        }
+ *         // Handle socket error.
  *     }
+ *     // Handle other cases.
  *
- *     if( callTlsRecvFunc == true )
- *     {
- *        bytesReceived = TLSRecv( pNetworkContext->tlsContext,
- *                                 pBuffer,
- *                                 bytesToRecv,
- *                                 MY_SOCKET_TIMEOUT );
- *        if( bytesReceived < 0 )
- *        {
- *           // If the error code represents a timeout, then the return
- *           // code should be translated to zero so that the caller
- *           // can retry the read operation.
- *           if( bytesReceived == MY_SOCKET_ERROR_TIMEOUT )
- *           {
- *              bytesReceived = 0;
- *           }
- *        }
- *        // Handle other cases.
- *     }
  *     return bytesReceived;
  * }
  * @endcode
@@ -153,14 +132,7 @@
  *                          pBuffer,
  *                          bytesToSend,
  *                          MY_SOCKET_TIMEOUT );
- *
- *      // If underlying TCP buffer is full, set the return value to zero
- *      // so that caller can retry the send operation.
- *     if( bytesSent == MY_SOCKET_ERROR_BUFFER_FULL )
- *     {
- *          bytesSent = 0;
- *     }
- *     else if( bytesSent < 0 )
+ *     if( bytesSent < 0 )
  *     {
  *         // Handle socket error.
  *     }
@@ -187,15 +159,6 @@ typedef struct NetworkContext NetworkContext_t;
  * @transportcallback
  * @brief Transport interface for receiving data on the network.
  *
- * @note It is RECOMMENDED that the transport receive implementation
- * does NOT block when requested to read a single byte. A single byte
- * read request can be made by the caller to check whether there is a
- * new frame available on the network for reading.
- * However, the receive implementation MAY block for a timeout period when
- * it is requested to read more than 1 byte. This is because once the caller
- * is aware that a new frame is available to read on the network, then
- * the likelihood of reading more than one byte over the network becomes high.
- *
  * @param[in] pNetworkContext Implementation-defined network context.
  * @param[in] pBuffer Buffer to receive the data into.
  * @param[in] bytesToRecv Number of bytes requested from the network.
@@ -204,10 +167,8 @@ typedef struct NetworkContext NetworkContext_t;
  * error.
  *
  * @note If no data is available on the network to read and no error
- * has occurred, zero MUST be the return value. A zero return value
- * SHOULD represent that the read operation can be retried by calling
- * the API function. Zero MUST NOT be returned if a network disconnection
- * has occurred.
+ * has occurred, zero MUST be the return value. Zero MUST NOT be used
+ * if a network disconnection has occurred.
  */
 /* @[define_transportrecv] */
 typedef int32_t ( * TransportRecv_t )( NetworkContext_t * pNetworkContext,
@@ -227,9 +188,7 @@ typedef int32_t ( * TransportRecv_t )( NetworkContext_t * pNetworkContext,
  *
  * @note If no data is transmitted over the network due to a full TX buffer and
  * no network error has occurred, this MUST return zero as the return value.
- * A zero return value SHOULD represent that the send operation can be retried
- * by calling the API function. Zero MUST NOT be returned if a network disconnection
- * has occurred.
+ * Zero MUST NOT be returned if a network disconnection has occurred.
  */
 /* @[define_transportsend] */
 typedef int32_t ( * TransportSend_t )( NetworkContext_t * pNetworkContext,

--- a/test/cbmc/include/core_http_config.h
+++ b/test/cbmc/include/core_http_config.h
@@ -39,6 +39,10 @@
  *
  * If the timeout expires, the #HTTPClient_Send function will return
  * #HTTPNetworkError.
+ *
+ * This is set to 1 to exit right away after a zero is received in the transport
+ * receive stub. There is no added value, in proving memory safety, to repeat
+ * the logic that checks if the retry timeout is reached.
  */
 #define HTTP_RECV_RETRY_TIMEOUT_MS    ( 1U )
 
@@ -52,6 +56,10 @@
  * transmission over the network through the transport send function.
  *
  * If the timeout expires, the #HTTPClient_Send function returns #HTTPNetworkError.
+ *
+ * This is set to 1 to exit right away after a zero is received in the transport
+ * send stub. There is no added value, in proving memory safety, to repeat
+ * the logic that checks if the retry timeout is reached.
  */
 #define HTTP_SEND_RETRY_TIMEOUT_MS    ( 1U )
 

--- a/test/cbmc/include/core_http_config.h
+++ b/test/cbmc/include/core_http_config.h
@@ -28,6 +28,32 @@
 #ifndef CORE_HTTP_CONFIG_H
 #define CORE_HTTP_CONFIG_H
 
-/* Empty configuration header simply for compilation. */
+/**
+ * @brief The maximum duration between non-empty network reads while receiving
+ * an HTTP response via the #HTTPClient_Send API function.
+ *
+ * The transport receive function may be called multiple times until the end of
+ * the response is detected by the parser. This timeout represents the maximum
+ * duration that is allowed without any data reception from the network for the
+ * incoming response.
+ *
+ * If the timeout expires, the #HTTPClient_Send function will return
+ * #HTTPNetworkError.
+ */
+#define HTTP_RECV_RETRY_TIMEOUT_MS    ( 1U )
+
+/**
+ * @brief The maximum duration between non-empty network transmissions while
+ * sending an HTTP request via the #HTTPClient_Send API function.
+ *
+ * When sending an HTTP request, the transport send function may be called multiple
+ * times until all of the required number of bytes are sent.
+ * This timeout represents the maximum duration that is allowed for no data
+ * transmission over the network through the transport send function.
+ *
+ * If the timeout expires, the #HTTPClient_Send function returns #HTTPNetworkError.
+ */
+#define HTTP_SEND_RETRY_TIMEOUT_MS    ( 1U )
+
 
 #endif /* ifndef CORE_HTTP_CONFIG_H */

--- a/test/cbmc/include/get_time_stub.h
+++ b/test/cbmc/include/get_time_stub.h
@@ -1,0 +1,38 @@
+/*
+ * coreHTTP v1.0.0
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file get_time_stub.h
+ * @brief Stub definition for the application defined callback to retrieve the
+ * current time in milliseconds.
+ */
+#ifndef GET_TIME_STUB_H_
+#define GET_TIME_STUB_H_
+
+/**
+ * Application defined callback to retrieve the current time in milliseconds.
+ *
+ * @return The current time in milliseconds.
+ */
+uint32_t GetCurrentTimeStub( void );
+
+#endif /* ifndef GET_TIME_STUB_H_ */

--- a/test/cbmc/proofs/HTTPClient_Send/HTTPClient_Send_harness.c
+++ b/test/cbmc/proofs/HTTPClient_Send/HTTPClient_Send_harness.c
@@ -28,6 +28,7 @@
 #include "core_http_client.h"
 #include "http_cbmc_state.h"
 #include "transport_interface_stubs.h"
+#include "get_time_stub.h"
 
 void HTTPClient_Send_harness()
 {
@@ -59,6 +60,11 @@ void HTTPClient_Send_harness()
          * but doing so makes CBMC run out of memory. */
         pTransportInterface->send = nondet_bool() ? NULL : TransportInterfaceSendStub;
         pTransportInterface->recv = nondet_bool() ? NULL : TransportInterfaceReceiveStub;
+    }
+
+    if( pResponse != NULL )
+    {
+        pResponse->getTime = nondet_boot() ? NULL : GetCurrentTimeStub;
     }
 
     HTTPClient_Send( pTransportInterface,

--- a/test/cbmc/proofs/HTTPClient_Send/Makefile
+++ b/test/cbmc/proofs/HTTPClient_Send/Makefile
@@ -69,6 +69,7 @@ PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROOF_SOURCES += $(SRCDIR)/test/cbmc/sources/http_cbmc_state.c
 PROOF_SOURCES += $(SRCDIR)/test/cbmc/stubs/HTTPClient_Send_http_parser_execute.c
 PROOF_SOURCES += $(SRCDIR)/test/cbmc/stubs/transport_interface_stubs.c
+PROOF_SOURCES += $(SRCDIR)/test/cbmc/stubs/get_time_stub.c
 PROOF_SOURCES += $(SRCDIR)/test/cbmc/stubs/strncpy.c
 PROOF_SOURCES += $(SRCDIR)/test/cbmc/stubs/httpHeaderStrncpy.c
 

--- a/test/cbmc/stubs/get_time_stub.c
+++ b/test/cbmc/stubs/get_time_stub.c
@@ -32,8 +32,8 @@ uint32_t GetCurrentTimeStub( void )
 {
     /* The HTTP relies on this timestamp in order to complete the network send
      * and receive loops. Returning an unbounded timestamp does not add value to
-     * the proofs as the HTTP library uses this time stamp only in an arithmetic
-     * operation to get the difference. In C arithmetic operations on unsigned
+     * the proofs as the HTTP library uses this timestamp only in an arithmetic
+     * operation to get the difference. In C, arithmetic operations on unsigned
      * integers are guaranteed to reliably wrap around with no adverse side
      * effects. If the time returned was unbounded, the network send and receive
      * loops could be unwound a large number of times making the proof execution

--- a/test/cbmc/stubs/get_time_stub.c
+++ b/test/cbmc/stubs/get_time_stub.c
@@ -1,0 +1,44 @@
+/*
+ * coreHTTP v1.0.0
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file get_time_stub.c
+ * @brief A stub to mock the retrieval of current time.
+ */
+#include "stdint.h"
+#include "get_time_stub.h"
+
+
+uint32_t GetCurrentTimeStub( void )
+{
+    /* The HTTP relies on this timestamp in order to complete the network send
+     * and receive loops. Returning an unbounded timestamp does not add value to
+     * the proofs as the HTTP library uses this time stamp only in an arithmetic
+     * operation to get the difference. In C arithmetic operations on unsigned
+     * integers are guaranteed to reliably wrap around with no adverse side
+     * effects. If the time returned was unbounded, the network send and receive
+     * loops could be unwound a large number of times making the proof execution
+     * very long. */
+    static uint32_t globalEntryTime = 0;
+
+    return globalEntryTime++;
+}

--- a/test/unit-test/core_http_config.h
+++ b/test/unit-test/core_http_config.h
@@ -23,6 +23,31 @@
 #ifndef CORE_HTTP_CONFIG_H__
 #define CORE_HTTP_CONFIG_H__
 
-/* Dummy core_http_config.h for building the library. */
+/**
+ * @brief The maximum duration between non-empty network reads while receiving
+ * an HTTP response via the #HTTPClient_Send API function.
+ *
+ * The transport receive function may be called multiple times until the end of
+ * the response is detected by the parser. This timeout represents the maximum
+ * duration that is allowed without any data reception from the network for the
+ * incoming response.
+ *
+ * If the timeout expires, the #HTTPClient_Send function will return
+ * #HTTPNetworkError.
+ */
+#define HTTP_RECV_RETRY_TIMEOUT_MS    ( 3U )
+
+/**
+ * @brief The maximum duration between non-empty network transmissions while
+ * sending an HTTP request via the #HTTPClient_Send API function.
+ *
+ * When sending an HTTP request, the transport send function may be called multiple
+ * times until all of the required number of bytes are sent.
+ * This timeout represents the maximum duration that is allowed for no data
+ * transmission over the network through the transport send function.
+ *
+ * If the timeout expires, the #HTTPClient_Send function returns #HTTPNetworkError.
+ */
+#define HTTP_SEND_RETRY_TIMEOUT_MS    ( 3U )
 
 #endif /* ifndef CORE_HTTP_CONFIG_H__ */

--- a/test/unit-test/core_http_send_utest.c
+++ b/test/unit-test/core_http_send_utest.c
@@ -1099,7 +1099,7 @@ void test_HTTPClient_Send_timeout_recv_retry( void )
     /* Set the optional time keeping function to retry the receive when zero
      * data is read from the network. */
     response.getTime = getTestTime;
-    /* On the first call to the transport recieve, return a zero. */
+    /* On the first call to the transport receive, return a zero. */
     recvTimeoutCall = 1;
 
     /* With HTTP_RECV_RETRY_TIMEOUT_MS set to greater than 1U in core_http_config.h

--- a/test/unit-test/core_http_send_utest.c
+++ b/test/unit-test/core_http_send_utest.c
@@ -1235,7 +1235,7 @@ void test_HTTPClient_Send_timeout_send_retry( void )
 
 /*-----------------------------------------------------------*/
 
-/* Test zero data is partially sent, but we receive zero data in the next
+/* Test data is partially sent, but we receive zero data in the next
  * call. */
 void test_HTTPClient_Send_timeout_send_retry_fail( void )
 {

--- a/test/unit-test/core_http_send_utest.c
+++ b/test/unit-test/core_http_send_utest.c
@@ -1122,7 +1122,7 @@ void test_HTTPClient_Send_null_response( void )
                                     HTTP_TEST_REQUEST_PUT_BODY_LENGTH,
                                     NULL,
                                     0U );
-    TEST_ASSERT_EQUAL( HTTPSuccess, returnStatus );
+    TEST_ASSERT_EQUAL( HTTPInvalidParameter, returnStatus );
 }
 
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
This PR implements send and receive timeouts for HTTPClient_Send() just as coreMQTT does for MQTT_ProcessLoop and MQTT_RecieveLoop did here: https://github.com/FreeRTOS/coreMQTT/pull/120

This extra layer of protection allows receiving or sending data after small interrupts in the transport layer.

Before, *sendHttpData()* had the potential to loop forever which would be devastating in a single threaded environment.
Before, receiving the response would stop as soon as zero was returned from the transport receive. Zero was updated in the transport_interface.h file to mean "no data available right now". We want to try again, if the application desires, for a bit more robustness.
