### PR TITLE
Add workflow to generate doxygen size tables

### DIFF
--- a/.github/workflows/memory_statistics.yml
+++ b/.github/workflows/memory_statistics.yml
@@ -1,0 +1,31 @@
+name: Memory statistics
+
+on:
+  workflow_dispatch:
+
+jobs:
+  memory_statistics:
+    name: Calculate object sizes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+            submodules: 'recursive'
+      - name: Measure sizes
+        uses: FreeRTOS/CI-CD-Github-Actions/memory_statistics@main
+        with:
+          lib_name: coreHTTP
+          src: |
+            source/core_http_client.c
+            source/dependency/3rdparty/http_parser/http_parser.c
+          include: |
+            source/include
+            source/interface
+            source/dependency/3rdparty/http_parser
+          compiler_flags: |
+            HTTP_DO_NOT_USE_CUSTOM_CONFIG
+      - name: Upload table
+        uses: actions/upload-artifact@v2
+        with:
+          name: size_table
+          path: size_table.html

--- a/docs/doxygen/config.doxyfile
+++ b/docs/doxygen/config.doxyfile
@@ -924,7 +924,7 @@ EXCLUDE_SYMBOLS        =
 # that contain example code fragments that are included (see the \include
 # command).
 
-EXAMPLE_PATH           = ./source/include
+EXAMPLE_PATH           = ./source/include ./docs/doxygen/include
 
 # If the value of the EXAMPLE_PATH tag contains directories, you can use the
 # EXAMPLE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp and

--- a/docs/doxygen/include/size_table.html
+++ b/docs/doxygen/include/size_table.html
@@ -1,0 +1,25 @@
+<table>
+    <tr>
+        <td colspan="3"><center><b>Code Size of coreHTTP (example generated with GCC for ARM Cortex-M)</b></center></td>
+    </tr>
+    <tr>
+        <td><b>File</b></td>
+        <td><b><center>With -O1 Optimization</center></b></td>
+        <td><b><center>With -Os Optimization</center></b></td>
+    </tr>
+    <tr>
+        <td>core_http_client.c</td>
+        <td><center>3.1K</center></td>
+        <td><center>2.5K</center></td>
+    </tr>
+    <tr>
+        <td>http_parser.c (third-party utility)</td>
+        <td><center>15.7K</center></td>
+        <td><center>13.0K</center></td>
+    </tr>
+    <tr>
+        <td><b>Total estimates</b></td>
+        <td><b><center>18.8K</center></b></td>
+        <td><b><center>15.5K</center></b></td>
+    </tr>
+</table>

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -17,31 +17,7 @@ Feature of HTTP/1.1 not supported in this library:
 @section http_memory_requirements Memory Requirements
 @brief Memory requirements of the HTTP Client library.
 
-<table>
-    <tr>
-        <td colspan="3"><center><b>Code size of HTTP Client library (example generated with GCC for ARM Cortex-M)</b></center></td>
-    </tr>
-    <tr>
-        <td><b>File</b></td>
-        <td><b>With -O1 Optimization</b></td>
-        <td><b>With -Os Optimization</b></td>
-    </tr>
-    <tr>
-        <td>core_http_client.c</td>
-        <td><center>3.1K</center></td>
-        <td><center>2.5K</center></td>
-    </tr>
-    <tr>
-        <td>http_parser.c (third-party utility)</td>
-        <td><center>15.7K</center></td>
-        <td><center>13.0K</center></td>
-    </tr>
-    <tr>
-        <td><b>Total estimate</b></td>
-        <td><center><b>18.8K</b></center></td>
-        <td><center><b>15.5K</b></center></td>
-    </tr>
-</table>
+@include{doc} size_table.html
  */
 
 /**


### PR DESCRIPTION
Adds a manual workflow that calls the memory statistics action to generate a size table.
Additionally refactors the doxygen table into its own file to make updating it easier.