### PR TITLE
Fix header field parser using case-insensitive compare

### DIFF
--- a/source/core_http_client.c
+++ b/source/core_http_client.c
@@ -2235,8 +2235,9 @@ static int findHeaderFieldParserCallback( http_parser * pHttpParser,
     assert( pContext->valueFound == 0U );
 
     /* Check whether the parsed header matches the header we are looking for. */
+    /* Each header field consists of a case-insensitive field name (RFC 7230, section 3.2). */
     if( ( fieldLen == pContext->fieldLen ) &&
-        ( strncmp( pContext->pField, pFieldLoc, fieldLen ) == 0 ) )
+        ( strncasecmp( pContext->pField, pFieldLoc, fieldLen ) == 0 ) )
     {
         LogDebug( ( "Found header field in response: "
                     "HeaderName=%.*s, HeaderLocation=0x%p",

--- a/test/cbmc/proofs/findHeaderFieldParserCallback/Makefile
+++ b/test/cbmc/proofs/findHeaderFieldParserCallback/Makefile
@@ -5,7 +5,7 @@ HARNESS_ENTRY=findHeaderFieldParserCallback_harness
 PROOF_UID=findHeaderFieldParserCallback
 HARNESS_FILE=$(HARNESS_ENTRY)
 
-# The header field length is bounded, so strncmp can be unwound to an expected
+# The header field length is bounded, so strncasecmp can be unwound to an expected
 # amount that won't make the proof run too long.
 MAX_HEADER_FIELD_LENGTH=10
 
@@ -13,7 +13,7 @@ DEFINES += -DMAX_HEADER_FIELD_LENGTH=$(MAX_HEADER_FIELD_LENGTH)
 INCLUDES +=
 
 REMOVE_FUNCTION_BODY +=
-UNWINDSET += strncmp.0:$(MAX_HEADER_FIELD_LENGTH)
+UNWINDSET += strncasecmp.0:$(MAX_HEADER_FIELD_LENGTH)
 
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROOF_SOURCES += $(SRCDIR)/test/cbmc/sources/http_cbmc_state.c


### PR DESCRIPTION
According to [RFC7230 Section 3.2](https://tools.ietf.org/html/rfc7230#section-3.2), parsing of HTTP header should be **case-insensitive**.
```text
3.2.  Header Fields
   Each header field consists of a case-insensitive field name followed
   by a colon (":"), optional leading whitespace, the field value, and
   optional trailing whitespace.
```
If referring to obsolete [RFC2616 Section4.2](https://tools.ietf.org/html/rfc2616#section-4.2)
```text
Each header field consists of a name followed by a colon (":") and the field value. Field names
are case-insensitive.
```
If referring to Hypertext Transfer Protocol Version 2 (HTTP/2) [RFC7540 Section 8.1.2](https://tools.ietf.org/html/rfc7540#section-8.1.2)
```text
   Just as in HTTP/1.x, header field names are strings of ASCII
   characters that are compared in a case-insensitive fashion.  However,
   header field names MUST be converted to lowercase prior to their
   encoding in HTTP/2.
```
If to be ready for HTTP/2, we should be ready to parse header field name such as "Content-Range" using case-insensitive. Referring to project "aws-iot-device-sdk-embedded-C" and "amazon-freertos".