### PR TITLE
Update memory table config for tagging

### DIFF
--- a/.github/memory_statistics_config.json
+++ b/.github/memory_statistics_config.json
@@ -2,7 +2,10 @@
   "lib_name": "coreHTTP",
   "src": [
     "source/core_http_client.c",
-    "source/dependency/3rdparty/http_parser/http_parser.c"
+    {
+      "file": "source/dependency/3rdparty/http_parser/http_parser.c",
+      "tag": "http-parser"
+    }
   ],
   "include": [
     "source/include",

--- a/docs/doxygen/include/size_table.html
+++ b/docs/doxygen/include/size_table.html
@@ -13,7 +13,7 @@
         <td><center>2.5K</center></td>
     </tr>
     <tr>
-        <td>http_parser.c (third-party utility)</td>
+        <td>http_parser.c (http-parser)</td>
         <td><center>15.7K</center></td>
         <td><center>13.0K</center></td>
     </tr>


### PR DESCRIPTION
The memory estimator tool no longer special cases paths including '3rdparty' to have a 'third-party utility' tag. This fixes it and sets the tag to be more descriptive.