### PR TITLE
Add function prototypes for exported functions to CBMC proof harnesses

### DIFF
--- a/test/cbmc/proofs/findHeaderFieldParserCallback/findHeaderFieldParserCallback_harness.c
+++ b/test/cbmc/proofs/findHeaderFieldParserCallback/findHeaderFieldParserCallback_harness.c
@@ -29,6 +29,10 @@
 #include "http_parser.h"
 #include "core_http_client.h"
 
+int __CPROVER_file_local_core_http_client_c_findHeaderFieldParserCallback( http_parser * pHttpParser,
+                                                                           const char * pFieldLoc,
+                                                                           size_t fieldLen );
+
 
 void findHeaderFieldParserCallback_harness()
 {

--- a/test/cbmc/proofs/findHeaderOnHeaderCompleteCallback/findHeaderOnHeaderCompleteCallback_harness.c
+++ b/test/cbmc/proofs/findHeaderOnHeaderCompleteCallback/findHeaderOnHeaderCompleteCallback_harness.c
@@ -29,6 +29,7 @@
 #include "http_parser.h"
 #include "core_http_client.h"
 
+int __CPROVER_file_local_core_http_client_c_findHeaderOnHeaderCompleteCallback( http_parser * pHttpParser );
 
 void findHeaderOnHeaderCompleteCallback_harness()
 {

--- a/test/cbmc/proofs/findHeaderValueParserCallback/findHeaderValueParserCallback_harness.c
+++ b/test/cbmc/proofs/findHeaderValueParserCallback/findHeaderValueParserCallback_harness.c
@@ -29,6 +29,9 @@
 #include "http_parser.h"
 #include "core_http_client.h"
 
+int __CPROVER_file_local_core_http_client_c_findHeaderValueParserCallback( http_parser * pHttpParser,
+                                                                           const char * pValueLoc,
+                                                                           size_t valueLen );
 
 void findHeaderValueParserCallback_harness()
 {

--- a/test/cbmc/proofs/httpParserOnBodyCallback/httpParserOnBodyCallback_harness.c
+++ b/test/cbmc/proofs/httpParserOnBodyCallback/httpParserOnBodyCallback_harness.c
@@ -28,6 +28,9 @@
 #include "http_cbmc_state.h"
 #include "http_parser.h"
 
+int __CPROVER_file_local_core_http_client_c_httpParserOnBodyCallback( http_parser * pHttpParser,
+                                                                      const char * pLoc,
+                                                                      size_t length );
 
 void httpParserOnBodyCallback_harness()
 {

--- a/test/cbmc/proofs/httpParserOnHeaderFieldCallback/httpParserOnHeaderFieldCallback_harness.c
+++ b/test/cbmc/proofs/httpParserOnHeaderFieldCallback/httpParserOnHeaderFieldCallback_harness.c
@@ -29,6 +29,9 @@
 #include "http_parser.h"
 #include "callback_stubs.h"
 
+int __CPROVER_file_local_core_http_client_c_httpParserOnHeaderFieldCallback( http_parser * pHttpParser,
+                                                                             const char * pLoc,
+                                                                             size_t length );
 
 void httpParserOnHeaderFieldCallback_harness()
 {

--- a/test/cbmc/proofs/httpParserOnHeaderValueCallback/httpParserOnHeaderValueCallback_harness.c
+++ b/test/cbmc/proofs/httpParserOnHeaderValueCallback/httpParserOnHeaderValueCallback_harness.c
@@ -28,6 +28,9 @@
 #include "http_cbmc_state.h"
 #include "http_parser.h"
 
+int __CPROVER_file_local_core_http_client_c_httpParserOnHeaderValueCallback( http_parser * pHttpParser,
+                                                                             const char * pLoc,
+                                                                             size_t length );
 
 void httpParserOnHeaderValueCallback_harness()
 {

--- a/test/cbmc/proofs/httpParserOnHeadersCompleteCallback/httpParserOnHeadersCompleteCallback_harness.c
+++ b/test/cbmc/proofs/httpParserOnHeadersCompleteCallback/httpParserOnHeadersCompleteCallback_harness.c
@@ -29,6 +29,7 @@
 #include "http_parser.h"
 #include "callback_stubs.h"
 
+int __CPROVER_file_local_core_http_client_c_httpParserOnHeadersCompleteCallback( http_parser * pHttpParser );
 
 void httpParserOnHeadersCompleteCallback_harness()
 {

--- a/test/cbmc/proofs/httpParserOnMessageBeginCallback/httpParserOnMessageBeginCallback_harness.c
+++ b/test/cbmc/proofs/httpParserOnMessageBeginCallback/httpParserOnMessageBeginCallback_harness.c
@@ -28,6 +28,7 @@
 #include "http_cbmc_state.h"
 #include "http_parser.h"
 
+int __CPROVER_file_local_core_http_client_c_httpParserOnMessageBeginCallback( http_parser * pHttpParser );
 
 void httpParserOnMessageBeginCallback_harness()
 {

--- a/test/cbmc/proofs/httpParserOnMessageCompleteCallback/httpParserOnMessageCompleteCallback_harness.c
+++ b/test/cbmc/proofs/httpParserOnMessageCompleteCallback/httpParserOnMessageCompleteCallback_harness.c
@@ -28,6 +28,7 @@
 #include "http_cbmc_state.h"
 #include "http_parser.h"
 
+int __CPROVER_file_local_core_http_client_c_httpParserOnMessageCompleteCallback( http_parser * pHttpParser );
 
 void httpParserOnMessageCompleteCallback_harness()
 {

--- a/test/cbmc/proofs/httpParserOnStatusCallback/httpParserOnStatusCallback_harness.c
+++ b/test/cbmc/proofs/httpParserOnStatusCallback/httpParserOnStatusCallback_harness.c
@@ -29,6 +29,10 @@
 #include "http_parser.h"
 #include "core_http_client.h"
 
+int __CPROVER_file_local_core_http_client_c_httpParserOnStatusCallback( http_parser * pHttpParser,
+                                                                        const char * pLoc,
+                                                                        size_t length );
+
 void httpParserOnStatusCallback_harness()
 {
     http_parser * pHttpParser;


### PR DESCRIPTION
The commit adds function protocols to CBMC proof harnesses for static functions exported with `--export-file-local-symbols`.  Prior to this commit, the harnesses were invoking the static function by its mangled name without declaring the mangled named, the compiler was inferring a default type for the declaration that conflicted with the type of the definition, and the linker was silently refusing to update the symbol table with the definition due to the type conflict.