### PR TITLE
Update http-parser version in manifest to reflect commit

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -4,7 +4,7 @@ description: |
   "Client implementation of the HTTP/1.1 specification for embedded devices.\n"
 dependencies:
   - name : "http-parser"
-    version: "v2.9.3"
+    version: "v2.9.4"
     repository:
       type: "git"
       url: "https://github.com/nodejs/http-parser"


### PR DESCRIPTION
The manifest hasn't been updated since the http-parser submodule pointer was updated so this simply updates the version number in the manifest