### PR TITLE
Add response buffer len check

### DIFF
--- a/source/core_http_client.c
+++ b/source/core_http_client.c
@@ -2201,6 +2201,10 @@ HTTPStatus_t HTTPClient_Send( const TransportInterface_t * pTransport,
     {
         LogError( ( "Parameter check failed: pResponse->pBuffer is NULL." ) );
     }
+    else if( pResponse->bufferLen == 0U )
+    {
+        LogError( ( "Parameter check failed: pResponse->bufferLen is zero." ) );
+    }
     else if( ( pRequestBodyBuf == NULL ) && ( reqBodyBufLen > 0U ) )
     {
         /* If there is no body to send we must ensure that the reqBodyBufLen is

--- a/test/unit-test/core_http_send_utest.c
+++ b/test/unit-test/core_http_send_utest.c
@@ -1489,6 +1489,25 @@ void test_HTTPClient_Send_null_response_buffer( void )
 
 /*-----------------------------------------------------------*/
 
+/* Test a NULL response buffer passed to the API. */
+void test_HTTPClient_Send_zero_response_buffer_len( void )
+{
+    HTTPStatus_t returnStatus = HTTPSuccess;
+
+    response.pBuffer = httpBuffer;
+    response.bufferLen = 0U;
+    returnStatus = HTTPClient_Send( &transportInterface,
+                                    &requestHeaders,
+                                    NULL,
+                                    0,
+                                    &response,
+                                    0 );
+
+    TEST_ASSERT_EQUAL( HTTPInvalidParameter, returnStatus );
+}
+
+/*-----------------------------------------------------------*/
+
 /* Test when reqBodyBufLen is greater than the max value of a 32-bit integer. */
 void test_HTTPClient_Send_request_body_buffer_length_gt_max( void )
 {

--- a/test/unit-test/core_http_send_utest.c
+++ b/test/unit-test/core_http_send_utest.c
@@ -1489,7 +1489,7 @@ void test_HTTPClient_Send_null_response_buffer( void )
 
 /*-----------------------------------------------------------*/
 
-/* Test a NULL response buffer passed to the API. */
+/* Test a 0 response buffer length passed to the API. */
 void test_HTTPClient_Send_zero_response_buffer_len( void )
 {
     HTTPStatus_t returnStatus = HTTPSuccess;

--- a/test/unit-test/core_http_utest.c
+++ b/test/unit-test/core_http_utest.c
@@ -996,7 +996,6 @@ void test_Http_AddRangeHeader_Insufficient_Memory( void )
                                        &expectedHeaders,
                                        PREEXISTING_HEADER_DATA );
     size_t preHeadersLen = testHeaders.headersLen;
-
     testRangeStart = 5;
     testRangeEnd = 10;
 

--- a/test/unit-test/core_http_utest.c
+++ b/test/unit-test/core_http_utest.c
@@ -996,6 +996,7 @@ void test_Http_AddRangeHeader_Insufficient_Memory( void )
                                        &expectedHeaders,
                                        PREEXISTING_HEADER_DATA );
     size_t preHeadersLen = testHeaders.headersLen;
+
     testRangeStart = 5;
     testRangeEnd = 10;
 


### PR DESCRIPTION
Add response buffer length check to prevent receive zero byte with transport interface in receiveAndParseHttpResponse.
```C
static HTTPStatus_t receiveAndParseHttpResponse( const TransportInterface_t * pTransport,
                                                 HTTPResponse_t * pResponse,
                                                 const HTTPRequestHeaders_t * pRequestHeaders )
{
...
    while( shouldRecv == 1U )
    {
        /* Receive the HTTP response data into the pResponse->pBuffer. */
        currentReceived = pTransport->recv( pTransport->pNetworkContext,
                                            pResponse->pBuffer + totalReceived,
                                            pResponse->bufferLen - totalReceived );
```