### PR TITLE
Changed function argument types to prevent compilation warnings.

### DIFF
--- a/source/core_http_client.c
+++ b/source/core_http_client.c
@@ -555,8 +555,8 @@ static HTTPStatus_t processLlhttpError( const llhttp_t * pHttpParser );
  * 0 if str1 is equal to str2
  * 1 if str1 is not equal to str2.
  */
-static int8_t caseInsensitiveStringCmp( const unsigned char * str1,
-                                        const unsigned char * str2,
+static int8_t caseInsensitiveStringCmp( const char * str1,
+                                        const char * str2,
                                         size_t n );
 
 /*-----------------------------------------------------------*/
@@ -568,8 +568,8 @@ static uint32_t getZeroTimestampMs( void )
 
 /*-----------------------------------------------------------*/
 
-static int8_t caseInsensitiveStringCmp( const unsigned char * str1,
-                                        const unsigned char * str2,
+static int8_t caseInsensitiveStringCmp( const char * str1,
+                                        const char * str2,
                                         size_t n )
 {
     size_t i = 0U;


### PR DESCRIPTION
Fixes a warning that comes when calling the caseInsensitiveStringCmp with a signed char * instead of unsigned.