### PR TITLE
Revert "unsigned char" parameter to caseInsensitiveStringCmp()

### DIFF
--- a/MISRA.md
+++ b/MISRA.md
@@ -7,7 +7,7 @@ The specific deviations, suppressed inline, are listed below.
 Additionally, [MISRA configuration file](https://github.com/FreeRTOS/coreHTTP/blob/main/tools/coverity/misra.config) contains the project wide deviations.
 
 ### Suppressed with Coverity Comments
-To find the violation references in the source files run grep on the source code
+To find the deviation references in the source files run grep on the source code
 with ( Assuming rule 5.4 violation; with justification in point 2 ):
 ```
 grep 'MISRA Ref 5.4.2' . -rI

--- a/source/core_http_client.c
+++ b/source/core_http_client.c
@@ -582,12 +582,12 @@ static int8_t caseInsensitiveStringCmp( const char * str1,
         secondChar = ( int8_t ) str2[ i ];
 
         /* Subtract 32 to go from uppercase to lowercase ASCII character */
-        if( firstChar >= 97 )
+        if( ( firstChar >= 97 ) && ( firstChar <= 122 ) )
         {
             firstChar = firstChar - 32;
         }
 
-        if( secondChar >= 97 )
+        if( ( secondChar >= 97 ) && ( secondChar <= 122 ) )
         {
             secondChar = secondChar - 32;
         }

--- a/source/core_http_client.c
+++ b/source/core_http_client.c
@@ -574,13 +574,24 @@ static int8_t caseInsensitiveStringCmp( const char * str1,
 {
     size_t i = 0U;
     /* Inclusion of inbetween variables for MISRA rule 13.2 compliance */
-    int32_t firstChar;
-    int32_t secondChar;
+    int8_t firstChar;
+    int8_t secondChar;
 
     for( i = 0U; i < n; i++ )
     {
-        firstChar = toupper( ( int32_t ) ( ( unsigned char ) str1[ i ] ) );
-        secondChar = toupper( ( int32_t ) ( ( unsigned char ) str2[ i ] ) );
+        firstChar = ( int8_t ) str1[ i ];
+        secondChar = ( int8_t ) str2[ i ];
+
+        /* Add 32 to go from uppercase to lowercase ASCII character */
+        if( ( firstChar >= 65 ) && ( firstChar <= 90 ) )
+        {
+            firstChar = firstChar + 32;
+        }
+
+        if( ( secondChar >= 65 ) && ( secondChar <= 90 ) )
+        {
+            secondChar = secondChar + 32;
+        }
 
         if( ( firstChar ) != ( secondChar ) )
         {

--- a/source/core_http_client.c
+++ b/source/core_http_client.c
@@ -573,21 +573,21 @@ static int8_t caseInsensitiveStringCmp( const char * str1,
 {
     size_t i = 0U;
     /* Inclusion of inbetween variables for MISRA rule 13.2 compliance */
-    int8_t firstChar;
-    int8_t secondChar;
+    char firstChar;
+    char secondChar;
 
     for( i = 0U; i < n; i++ )
     {
-        firstChar = ( int8_t ) str1[ i ];
-        secondChar = ( int8_t ) str2[ i ];
+        firstChar = str1[ i ];
+        secondChar = str2[ i ];
 
         /* Subtract 32 to go from uppercase to lowercase ASCII character */
-        if( ( firstChar >= 97 ) && ( firstChar <= 122 ) )
+        if( ( firstChar >= 'a' ) && ( firstChar <= 'z' ) )
         {
             firstChar = firstChar - 32;
         }
 
-        if( ( secondChar >= 97 ) && ( secondChar <= 122 ) )
+        if( ( secondChar >= 'a' ) && ( secondChar <= 'z' ) )
         {
             secondChar = secondChar - 32;
         }

--- a/source/core_http_client.c
+++ b/source/core_http_client.c
@@ -555,8 +555,8 @@ static HTTPStatus_t processLlhttpError( const llhttp_t * pHttpParser );
  * 0 if str1 is equal to str2
  * 1 if str1 is not equal to str2.
  */
-static int8_t caseInsensitiveStringCmp( const unsigned char * str1,
-                                        const unsigned char * str2,
+static int8_t caseInsensitiveStringCmp( const char * str1,
+                                        const char * str2,
                                         size_t n );
 
 /*-----------------------------------------------------------*/
@@ -568,19 +568,19 @@ static uint32_t getZeroTimestampMs( void )
 
 /*-----------------------------------------------------------*/
 
-static int8_t caseInsensitiveStringCmp( const unsigned char * str1,
-                                        const unsigned char * str2,
+static int8_t caseInsensitiveStringCmp( const char * str1,
+                                        const char * str2,
                                         size_t n )
 {
     size_t i = 0U;
-    /* Inclusion of inbetween variables for coverity rule 13.2 compliance */
+    /* Inclusion of inbetween variables for MISRA rule 13.2 compliance */
     int32_t firstChar;
     int32_t secondChar;
 
     for( i = 0U; i < n; i++ )
     {
-        firstChar = toupper( ( int32_t ) ( str1[ i ] ) );
-        secondChar = toupper( ( ( int32_t ) str2[ i ] ) );
+        firstChar = toupper( ( int32_t ) ( ( unsigned char ) str1[ i ] ) );
+        secondChar = toupper( ( int32_t ) ( ( unsigned char ) str2[ i ] ) );
 
         if( ( firstChar ) != ( secondChar ) )
         {

--- a/source/core_http_client.c
+++ b/source/core_http_client.c
@@ -582,7 +582,7 @@ static int8_t caseInsensitiveStringCmp( const char * str1,
         firstChar = str1[ i ];
         secondChar = str2[ i ];
 
-        /* Subtract 32 to go from uppercase to lowercase ASCII character */
+        /* Subtract 32 to go from lowercase to uppercase ASCII character */
         if( ( firstChar >= 'a' ) && ( firstChar <= 'z' ) )
         {
             firstChar = firstChar - offset;

--- a/source/core_http_client.c
+++ b/source/core_http_client.c
@@ -575,6 +575,7 @@ static int8_t caseInsensitiveStringCmp( const char * str1,
     /* Inclusion of inbetween variables for MISRA rule 13.2 compliance */
     char firstChar;
     char secondChar;
+    int8_t offset = 'a' - 'A';
 
     for( i = 0U; i < n; i++ )
     {
@@ -584,12 +585,12 @@ static int8_t caseInsensitiveStringCmp( const char * str1,
         /* Subtract 32 to go from uppercase to lowercase ASCII character */
         if( ( firstChar >= 'a' ) && ( firstChar <= 'z' ) )
         {
-            firstChar = firstChar - 32;
+            firstChar = firstChar - offset;
         }
 
         if( ( secondChar >= 'a' ) && ( secondChar <= 'z' ) )
         {
-            secondChar = secondChar - 32;
+            secondChar = secondChar - offset;
         }
 
         if( ( firstChar ) != ( secondChar ) )

--- a/source/core_http_client.c
+++ b/source/core_http_client.c
@@ -582,12 +582,12 @@ static int8_t caseInsensitiveStringCmp( const char * str1,
         secondChar = ( int8_t ) str2[ i ];
 
         /* Subtract 32 to go from uppercase to lowercase ASCII character */
-        if( ( firstChar >= 97 ) && ( firstChar <= 122 ) )
+        if( firstChar >= 97 )
         {
             firstChar = firstChar - 32;
         }
 
-        if( ( secondChar >= 97 ) && ( secondChar <= 122 ) )
+        if( secondChar >= 97 )
         {
             secondChar = secondChar - 32;
         }

--- a/source/core_http_client.c
+++ b/source/core_http_client.c
@@ -575,6 +575,7 @@ static int8_t caseInsensitiveStringCmp( const char * str1,
     /* Inclusion of inbetween variables for MISRA rule 13.2 compliance */
     char firstChar;
     char secondChar;
+    /* Get the offset from a lowercase to capital character in a MISRA compliant way */
     int8_t offset = 'a' - 'A';
 
     for( i = 0U; i < n; i++ )
@@ -582,7 +583,7 @@ static int8_t caseInsensitiveStringCmp( const char * str1,
         firstChar = str1[ i ];
         secondChar = str2[ i ];
 
-        /* Subtract 32 to go from lowercase to uppercase ASCII character */
+        /* Subtract offset to go from lowercase to uppercase ASCII character */
         if( ( firstChar >= 'a' ) && ( firstChar <= 'z' ) )
         {
             firstChar = firstChar - offset;

--- a/source/core_http_client.c
+++ b/source/core_http_client.c
@@ -555,7 +555,6 @@ static HTTPStatus_t processLlhttpError( const llhttp_t * pHttpParser );
  * 0 if str1 is equal to str2
  * 1 if str1 is not equal to str2.
  */
-#include <stdio.h>
 static int8_t caseInsensitiveStringCmp( const char * str1,
                                         const char * str2,
                                         size_t n );
@@ -568,7 +567,6 @@ static uint32_t getZeroTimestampMs( void )
 }
 
 /*-----------------------------------------------------------*/
-
 static int8_t caseInsensitiveStringCmp( const char * str1,
                                         const char * str2,
                                         size_t n )

--- a/source/core_http_client.c
+++ b/source/core_http_client.c
@@ -555,6 +555,7 @@ static HTTPStatus_t processLlhttpError( const llhttp_t * pHttpParser );
  * 0 if str1 is equal to str2
  * 1 if str1 is not equal to str2.
  */
+#include <stdio.h>
 static int8_t caseInsensitiveStringCmp( const char * str1,
                                         const char * str2,
                                         size_t n );
@@ -582,15 +583,15 @@ static int8_t caseInsensitiveStringCmp( const char * str1,
         firstChar = ( int8_t ) str1[ i ];
         secondChar = ( int8_t ) str2[ i ];
 
-        /* Add 32 to go from uppercase to lowercase ASCII character */
-        if( ( firstChar >= 65 ) && ( firstChar <= 90 ) )
+        /* Subtract 32 to go from uppercase to lowercase ASCII character */
+        if( ( firstChar >= 97 ) && ( firstChar <= 122 ) )
         {
-            firstChar = firstChar + 32;
+            firstChar = firstChar - 32;
         }
 
-        if( ( secondChar >= 65 ) && ( secondChar <= 90 ) )
+        if( ( secondChar >= 97 ) && ( secondChar <= 122 ) )
         {
-            secondChar = secondChar + 32;
+            secondChar = secondChar - 32;
         }
 
         if( ( firstChar ) != ( secondChar ) )

--- a/source/include/core_http_client_private.h
+++ b/source/include/core_http_client_private.h
@@ -213,12 +213,12 @@ typedef enum HTTPParsingState_t
  */
 typedef struct findHeaderContext
 {
-    const unsigned char * pField; /**< The field that is being searched for. */
-    size_t fieldLen;              /**< The length of pField. */
-    const char ** pValueLoc;      /**< The location of the value found in the buffer. */
-    size_t * pValueLen;           /**< the length of the value found. */
-    uint8_t fieldFound;           /**< Indicates that the header field was found during parsing. */
-    uint8_t valueFound;           /**< Indicates that the header value was found during parsing. */
+    const char * pField;     /**< The field that is being searched for. */
+    size_t fieldLen;         /**< The length of pField. */
+    const char ** pValueLoc; /**< The location of the value found in the buffer. */
+    size_t * pValueLen;      /**< the length of the value found. */
+    uint8_t fieldFound;      /**< Indicates that the header field was found during parsing. */
+    uint8_t valueFound;      /**< Indicates that the header value was found during parsing. */
 } findHeaderContext_t;
 
 /**

--- a/test/unit-test/core_http_utest.c
+++ b/test/unit-test/core_http_utest.c
@@ -1408,7 +1408,7 @@ void test_Http_ReadHeader_Invalid_Response_Only_Header_Field_Found()
 
 
 /**
- * @brief Test happy path with zero-iniestHeaders and requestInfo.
+ * @brief Test happy path with zero-initialized requestHeaders and requestInfo.
  * Use characters in the header with ASCII values higher than 'z'.
  */
 void test_caseInsensitiveStringCmp()

--- a/test/unit-test/core_http_utest.c
+++ b/test/unit-test/core_http_utest.c
@@ -153,7 +153,7 @@ static const char * pTestResponseEmptyValue = "HTTP/1.1 200 OK\r\n"
 #define HEADER_INVALID_PARAMS        "Header"
 #define HEADER_INVALID_PARAMS_LEN    ( sizeof( HEADER_INVALID_PARAMS ) - 1 )
 
-#define HEADER_IN_BUFFER             "test-header1"
+#define HEADER_IN_BUFFER             "teSt-hEader1"
 #define HEADER_IN_BUFFER_LEN         ( sizeof( HEADER_IN_BUFFER ) - 1 )
 
 #define HEADER_NOT_IN_BUFFER         "header-not-in-buffer"


### PR DESCRIPTION
A team member ran into an issue when compiling tests linking with this repo.
Reverting a change we had come up with to a MISRA compliant version of this original function.