### PR TITLE
Add CBMC proof-running GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,3 +124,19 @@ jobs:
         with:
             config: .github/memory_statistics_config.json
             check_against: docs/doxygen/include/size_table.md
+  proof_ci:
+    runs-on: cbmc_ubuntu-latest_64-core
+    steps:
+      - name: Set up CBMC runner
+        uses: FreeRTOS/CI-CD-Github-Actions/set_up_cbmc_runner@main
+        with:
+          kissat_tag: latest
+          cbmc_version: "5.73.0"
+      - run: |
+          git submodule update --init --recursive --checkout
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends gcc-multilib build-essential
+      - name: Run CBMC
+        uses: FreeRTOS/CI-CD-Github-Actions/run_cbmc@main
+        with:
+          proofs_dir: test/cbmc/proofs

--- a/test/cbmc/proofs/HTTPClient_AddHeader/Makefile
+++ b/test/cbmc/proofs/HTTPClient_AddHeader/Makefile
@@ -58,4 +58,6 @@ PROOF_SOURCES += $(SRCDIR)/test/cbmc/stubs/httpHeaderStrncpy.c
 
 PROJECT_SOURCES += $(SRCDIR)/source/core_http_client.c
 
+EXTERNAL_SAT_SOLVER := kissat
+
 include ../Makefile.common

--- a/test/cbmc/proofs/HTTPClient_AddRangeHeader/Makefile
+++ b/test/cbmc/proofs/HTTPClient_AddRangeHeader/Makefile
@@ -48,4 +48,6 @@ PROOF_SOURCES += $(SRCDIR)/test/cbmc/stubs/httpHeaderStrncpy.c
 
 PROJECT_SOURCES += $(SRCDIR)/source/core_http_client.c
 
+EXTERNAL_SAT_SOLVER := kissat
+
 include ../Makefile.common

--- a/test/cbmc/proofs/HTTPClient_InitializeRequestHeaders/Makefile
+++ b/test/cbmc/proofs/HTTPClient_InitializeRequestHeaders/Makefile
@@ -57,4 +57,6 @@ PROOF_SOURCES += $(SRCDIR)/test/cbmc/stubs/httpHeaderStrncpy.c
 
 PROJECT_SOURCES += $(SRCDIR)/source/core_http_client.c
 
+EXTERNAL_SAT_SOLVER := kissat
+
 include ../Makefile.common

--- a/test/cbmc/proofs/HTTPClient_InitializeRequestHeaders/cbmc-proof.txt
+++ b/test/cbmc/proofs/HTTPClient_InitializeRequestHeaders/cbmc-proof.txt
@@ -1,1 +1,0 @@
-# This file marks this directory as containing a CBMC proof.

--- a/test/cbmc/proofs/HTTPClient_ReadHeader/Makefile
+++ b/test/cbmc/proofs/HTTPClient_ReadHeader/Makefile
@@ -44,4 +44,6 @@ PROOF_SOURCES += $(SRCDIR)/test/cbmc/stubs/HTTPClient_ReadHeader_llhttp_execute.
 PROJECT_SOURCES += $(SRCDIR)/source/core_http_client.c
 
 
+EXTERNAL_SAT_SOLVER := kissat
+
 include ../Makefile.common

--- a/test/cbmc/proofs/HTTPClient_Send/Makefile
+++ b/test/cbmc/proofs/HTTPClient_Send/Makefile
@@ -74,4 +74,6 @@ PROOF_SOURCES += $(SRCDIR)/test/cbmc/stubs/httpHeaderStrncpy.c
 
 PROJECT_SOURCES += $(SRCDIR)/source/core_http_client.c
 
+EXTERNAL_SAT_SOLVER := kissat
+
 include ../Makefile.common

--- a/test/cbmc/proofs/HTTPClient_strerror/Makefile
+++ b/test/cbmc/proofs/HTTPClient_strerror/Makefile
@@ -33,4 +33,6 @@ PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 
 PROJECT_SOURCES += $(SRCDIR)/source/core_http_client.c
 
+EXTERNAL_SAT_SOLVER := kissat
+
 include ../Makefile.common

--- a/test/cbmc/proofs/findHeaderFieldParserCallback/Makefile
+++ b/test/cbmc/proofs/findHeaderFieldParserCallback/Makefile
@@ -20,4 +20,6 @@ PROOF_SOURCES += $(SRCDIR)/test/cbmc/sources/http_cbmc_state.c
 
 PROJECT_SOURCES += $(SRCDIR)/source/core_http_client.c
 
+EXTERNAL_SAT_SOLVER := kissat
+
 include ../Makefile.common

--- a/test/cbmc/proofs/findHeaderOnHeaderCompleteCallback/Makefile
+++ b/test/cbmc/proofs/findHeaderOnHeaderCompleteCallback/Makefile
@@ -16,4 +16,6 @@ PROOF_SOURCES += $(SRCDIR)/test/cbmc/sources/http_cbmc_state.c
 
 PROJECT_SOURCES += $(SRCDIR)/source/core_http_client.c
 
+EXTERNAL_SAT_SOLVER := kissat
+
 include ../Makefile.common

--- a/test/cbmc/proofs/findHeaderValueParserCallback/Makefile
+++ b/test/cbmc/proofs/findHeaderValueParserCallback/Makefile
@@ -16,4 +16,6 @@ PROOF_SOURCES += $(SRCDIR)/test/cbmc/sources/http_cbmc_state.c
 
 PROJECT_SOURCES += $(SRCDIR)/source/core_http_client.c
 
+EXTERNAL_SAT_SOLVER := kissat
+
 include ../Makefile.common

--- a/test/cbmc/proofs/httpParserOnBodyCallback/Makefile
+++ b/test/cbmc/proofs/httpParserOnBodyCallback/Makefile
@@ -18,4 +18,6 @@ PROOF_SOURCES += $(SRCDIR)/test/cbmc/stubs/memmove.c
 
 PROJECT_SOURCES += $(SRCDIR)/source/core_http_client.c
 
+EXTERNAL_SAT_SOLVER := kissat
+
 include ../Makefile.common

--- a/test/cbmc/proofs/httpParserOnBodyCallback/cbmc-proof.txt
+++ b/test/cbmc/proofs/httpParserOnBodyCallback/cbmc-proof.txt
@@ -1,1 +1,0 @@
-# This file marks this directory as containing a CBMC proof.

--- a/test/cbmc/proofs/httpParserOnHeaderFieldCallback/Makefile
+++ b/test/cbmc/proofs/httpParserOnHeaderFieldCallback/Makefile
@@ -17,4 +17,6 @@ PROOF_SOURCES += $(SRCDIR)/test/cbmc/stubs/callback_stubs.c
 
 PROJECT_SOURCES += $(SRCDIR)/source/core_http_client.c
 
+EXTERNAL_SAT_SOLVER := kissat
+
 include ../Makefile.common

--- a/test/cbmc/proofs/httpParserOnHeaderValueCallback/Makefile
+++ b/test/cbmc/proofs/httpParserOnHeaderValueCallback/Makefile
@@ -16,4 +16,6 @@ PROOF_SOURCES += $(SRCDIR)/test/cbmc/sources/http_cbmc_state.c
 
 PROJECT_SOURCES += $(SRCDIR)/source/core_http_client.c
 
+EXTERNAL_SAT_SOLVER := kissat
+
 include ../Makefile.common

--- a/test/cbmc/proofs/httpParserOnHeadersCompleteCallback/Makefile
+++ b/test/cbmc/proofs/httpParserOnHeadersCompleteCallback/Makefile
@@ -17,4 +17,6 @@ PROOF_SOURCES += $(SRCDIR)/test/cbmc/stubs/callback_stubs.c
 
 PROJECT_SOURCES += $(SRCDIR)/source/core_http_client.c
 
+EXTERNAL_SAT_SOLVER := kissat
+
 include ../Makefile.common

--- a/test/cbmc/proofs/httpParserOnMessageBeginCallback/Makefile
+++ b/test/cbmc/proofs/httpParserOnMessageBeginCallback/Makefile
@@ -16,4 +16,6 @@ PROOF_SOURCES += $(SRCDIR)/test/cbmc/sources/http_cbmc_state.c
 
 PROJECT_SOURCES += $(SRCDIR)/source/core_http_client.c
 
+EXTERNAL_SAT_SOLVER := kissat
+
 include ../Makefile.common

--- a/test/cbmc/proofs/httpParserOnMessageCompleteCallback/Makefile
+++ b/test/cbmc/proofs/httpParserOnMessageCompleteCallback/Makefile
@@ -16,4 +16,6 @@ PROOF_SOURCES += $(SRCDIR)/test/cbmc/sources/http_cbmc_state.c
 
 PROJECT_SOURCES += $(SRCDIR)/source/core_http_client.c
 
+EXTERNAL_SAT_SOLVER := kissat
+
 include ../Makefile.common

--- a/test/cbmc/proofs/httpParserOnStatusCallback/Makefile
+++ b/test/cbmc/proofs/httpParserOnStatusCallback/Makefile
@@ -16,4 +16,6 @@ PROOF_SOURCES += $(SRCDIR)/test/cbmc/sources/http_cbmc_state.c
 
 PROJECT_SOURCES += $(SRCDIR)/source/core_http_client.c
 
+EXTERNAL_SAT_SOLVER := kissat
+
 include ../Makefile.common

--- a/test/cbmc/proofs/lib/print_tool_versions.py
+++ b/test/cbmc/proofs/lib/print_tool_versions.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+
+import logging
+import pathlib
+import shutil
+import subprocess
+
+
+_TOOLS = [
+    "cadical",
+    "cbmc",
+    "cbmc-viewer",
+    "cbmc-starter-kit-update",
+    "kissat",
+    "litani",
+]
+
+
+def _format_versions(table):
+    lines = [
+        "<table>",
+        '<tr><td colspan="2" style="font-weight: bold">Tool Versions</td></tr>',
+    ]
+    for tool, version in table.items():
+        if version:
+            v_str = f'<code><pre style="margin: 0">{version}</pre></code>'
+        else:
+            v_str = '<em>not found</em>'
+        lines.append(
+            f'<tr><td style="font-weight: bold; padding-right: 1em; '
+            f'text-align: right;">{tool}:</td>'
+            f'<td>{v_str}</td></tr>')
+    lines.append("</table>")
+    return "\n".join(lines)
+
+
+def _get_tool_versions():
+    ret = {}
+    for tool in _TOOLS:
+        err = f"Could not determine version of {tool}: "
+        ret[tool] = None
+        if not shutil.which(tool):
+            logging.error("%s'%s' not found on $PATH", err, tool)
+            continue
+        cmd = [tool, "--version"]
+        proc = subprocess.Popen(cmd, text=True, stdout=subprocess.PIPE)
+        try:
+            out, _ = proc.communicate(timeout=10)
+        except subprocess.TimeoutExpired:
+            logging.error("%s'%s --version' timed out", err, tool)
+            continue
+        if proc.returncode:
+            logging.error(
+                "%s'%s --version' returned %s", err, tool, str(proc.returncode))
+            continue
+        ret[tool] = out.strip()
+    return ret
+
+
+def main():
+    exe_name = pathlib.Path(__file__).name
+    logging.basicConfig(format=f"{exe_name}: %(message)s")
+
+    table = _get_tool_versions()
+    out = _format_versions(table)
+    print(out)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This commit adds a GitHub Action that runs the CBMC proofs upon every push and pull request. This is intended to replace the current CBMC CI.