### PR TITLE
[support presigned URL] support http request without HTTP_USER_AGENT_FIELD

### DIFF
--- a/docs/doxygen/include/size_table.md
+++ b/docs/doxygen/include/size_table.md
@@ -9,7 +9,7 @@
     </tr>
     <tr>
         <td>core_http_client.c</td>
-        <td><center>3.1K</center></td>
+        <td><center>3.2K</center></td>
         <td><center>2.5K</center></td>
     </tr>
     <tr>
@@ -29,7 +29,7 @@
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
-        <td><b><center>23.9K</center></b></td>
+        <td><b><center>24.0K</center></b></td>
         <td><b><center>20.7K</center></b></td>
     </tr>
 </table>

--- a/source/core_http_client.c
+++ b/source/core_http_client.c
@@ -1632,12 +1632,15 @@ HTTPStatus_t HTTPClient_InitializeRequestHeaders( HTTPRequestHeaders_t * pReques
 
     if( returnStatus == HTTPSuccess )
     {
-        /* Write "User-Agent: <Value>". */
-        returnStatus = addHeader( pRequestHeaders,
-                                  HTTP_USER_AGENT_FIELD,
-                                  HTTP_USER_AGENT_FIELD_LEN,
-                                  HTTP_USER_AGENT_VALUE,
-                                  HTTP_USER_AGENT_VALUE_LEN );
+        if( ( HTTP_REQUEST_NO_USER_AGENT_FLAG & pRequestInfo->reqFlags ) == 0U )
+        {
+            /* Write "User-Agent: <Value>". */
+            returnStatus = addHeader( pRequestHeaders,
+                                      HTTP_USER_AGENT_FIELD,
+                                      HTTP_USER_AGENT_FIELD_LEN,
+                                      HTTP_USER_AGENT_VALUE,
+                                      HTTP_USER_AGENT_VALUE_LEN );
+        }
     }
 
     if( returnStatus == HTTPSuccess )

--- a/source/include/core_http_client.h
+++ b/source/include/core_http_client.h
@@ -111,7 +111,7 @@
  *
  * This flag is valid only for #HTTPRequestInfo_t reqFlags parameter.
  */
-#define HTTP_REQUEST_KEEP_ALIVE_FLAG    0x1U
+#define HTTP_REQUEST_KEEP_ALIVE_FLAG       0x1U
 
 /**
  * @ingroup http_request_flags
@@ -123,7 +123,7 @@
  *
  * This flag is valid only for #HTTPRequestInfo_t reqFlags parameter.
  */
-#define HTTP_REQUEST_NO_USER_AGENT_FLAG     0x2U
+#define HTTP_REQUEST_NO_USER_AGENT_FLAG    0x2U
 
 /**
  * @defgroup http_response_flags HTTPResponse_t Flags

--- a/source/include/core_http_client.h
+++ b/source/include/core_http_client.h
@@ -115,10 +115,9 @@
 
 /**
  * @ingroup http_request_flags
- * @brief Set this flag to indicate that the request is for a persistent
- * connection.
+ * @brief Set this flag to skip the User-Agent in the request headers.
  *
- * Setting this will cause a "Connection: Keep-Alive" to be written to the
+ * Setting this will cause the "User-Agent: <Value>" to be omitted in the
  * request headers.
  *
  * This flag is valid only for #HTTPRequestInfo_t reqFlags parameter.

--- a/source/include/core_http_client.h
+++ b/source/include/core_http_client.h
@@ -114,6 +114,18 @@
 #define HTTP_REQUEST_KEEP_ALIVE_FLAG    0x1U
 
 /**
+ * @ingroup http_request_flags
+ * @brief Set this flag to indicate that the request is for a persistent
+ * connection.
+ *
+ * Setting this will cause a "Connection: Keep-Alive" to be written to the
+ * request headers.
+ *
+ * This flag is valid only for #HTTPRequestInfo_t reqFlags parameter.
+ */
+#define HTTP_REQUEST_NO_USER_AGENT_FLAG     0x2U
+
+/**
  * @defgroup http_response_flags HTTPResponse_t Flags
  * @brief Flags for #HTTPResponse_t.respFlags.
  * These flags are populated in #HTTPResponse_t.respFlags by the #HTTPClient_Send


### PR DESCRIPTION
Support http request without HTTP_USER_AGENT_FIELD

Description
-----------
As discussed in https://github.com/aws/aws-iot-device-sdk-embedded-C/issues/1887 I have made changes to an existing demo http_demo_s3_download to generate a presigned URL instead of directly downloading the file.
I'm planning, if the changes to the submodules are accepted, to then generate a new demo called http_demo_s3_presigned_url or something like that.
You can see/test my work at https://github.com/giuspen/aws-iot-device-sdk-embedded-C/tree/GP_http_demo_s3_download_test_signature (only generate presigned URL) or https://github.com/giuspen/aws-iot-device-sdk-embedded-C/tree/GP_http_demo_s3_download_test_signature2 (download and also generate presigned URL)

Test Steps
-----------
Exact same requirements of original demo http_demo_s3_download

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
https://github.com/aws/aws-iot-device-sdk-embedded-C/issues/1887
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
