### PR TITLE
Add compiler warning check in the CI workflow

### DIFF
--- a/.github/.cSpellWords.txt
+++ b/.github/.cSpellWords.txt
@@ -49,4 +49,9 @@ utest
 vect
 Vect
 VECT
+Wconversion
+Werror
+Weverything
+Wextra
+Wpedantic
 Wunused

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,15 @@ jobs:
       - name: Build
         run: |
           sudo apt-get install -y lcov
+
+          # Build the coverity analysis project as well to check compiler warning.
+          # Coverity analysis project builds coreHTTP source file only. llhttp source
+          # files are not built in this target.
           cmake -S test -B build/ \
           -G "Unix Makefiles" \
           -DCMAKE_BUILD_TYPE=Debug \
           -DUNITTEST=1 \
+          -DCOV_ANALYSIS=1 \
           -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -DNDEBUG'
           make -C build/ all
 

--- a/source/core_http_client.c
+++ b/source/core_http_client.c
@@ -545,12 +545,12 @@ static int8_t caseInsensitiveStringCmp( const char * str1,
         /* Subtract offset to go from lowercase to uppercase ASCII character */
         if( ( firstChar >= 'a' ) && ( firstChar <= 'z' ) )
         {
-            firstChar = firstChar - offset;
+            firstChar = ( char ) ( firstChar - offset );
         }
 
         if( ( secondChar >= 'a' ) && ( secondChar <= 'z' ) )
         {
-            secondChar = secondChar - offset;
+            secondChar = ( char ) ( secondChar - offset );
         }
 
         if( ( firstChar ) != ( secondChar ) )
@@ -1249,6 +1249,7 @@ static uint8_t convertInt32ToAscii( int32_t value,
     uint8_t numOfDigits = 0U;
     uint8_t index = 0U;
     uint8_t isNegative = 0U;
+    int32_t bufferIndex;
     char temp = '\0';
 
     assert( pBuffer != NULL );
@@ -1263,7 +1264,7 @@ static uint8_t convertInt32ToAscii( int32_t value,
         *pBuffer = '-';
 
         /* Convert the value to its absolute representation. */
-        absoluteValue = value * -1;
+        absoluteValue = value * ( -1 );
     }
 
     /* Write the absolute integer value in reverse ASCII representation. */
@@ -1279,11 +1280,12 @@ static uint8_t convertInt32ToAscii( int32_t value,
     for( index = 0U; index < ( numOfDigits / 2U ); index++ )
     {
         temp = pBuffer[ isNegative + index ];
-        pBuffer[ isNegative + index ] = pBuffer[ isNegative + numOfDigits - index - 1U ];
-        pBuffer[ isNegative + numOfDigits - index - 1U ] = temp;
+        bufferIndex = ( int32_t ) isNegative + ( int32_t ) numOfDigits - ( int32_t ) index - 1;
+        pBuffer[ isNegative + index ] = pBuffer[ bufferIndex ];
+        pBuffer[ bufferIndex ] = temp;
     }
 
-    return( isNegative + numOfDigits );
+    return ( uint8_t ) ( isNegative + numOfDigits );
 }
 
 /*-----------------------------------------------------------*/

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -56,23 +56,13 @@ if( COV_ANALYSIS )
         # Build HTTP library target without logging
         -DNDEBUG
 
-        ### Gnu/Clang C Options
-        $<$<COMPILE_LANG_AND_ID:C,GNU>:-fdiagnostics-color=always>
-        $<$<COMPILE_LANG_AND_ID:C,Clang>:-fcolor-diagnostics>
-
-        $<$<COMPILE_LANG_AND_ID:C,Clang,GNU>:-Wall>
-        $<$<COMPILE_LANG_AND_ID:C,Clang,GNU>:-Wextra>
-        $<$<COMPILE_LANG_AND_ID:C,Clang,GNU>:-Wpedantic>
-        $<$<COMPILE_LANG_AND_ID:C,Clang,GNU>:-Werror>
-        $<$<COMPILE_LANG_AND_ID:C,Clang,GNU>:-Wconversion>
-        $<$<COMPILE_LANG_AND_ID:C,Clang>:-Weverything>
-
-        # Suppressions required to build clean with clang.
-        $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-unused-macros>
-        $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-padded>
-        $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-missing-variable-declarations>
-        $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-covered-switch-default>
-        $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-cast-align>
+        # GCC compiler option
+        -Wall
+        -Wextra
+        -Wpedantic
+        -Werror
+        -Wconversion
+        -Weverything
     )
 endif()
 # ===================== Clone needed third-party libraries ======================

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -44,7 +44,7 @@ if( COV_ANALYSIS )
 
     # Target for Coverity analysis that builds the library.
     add_library( coverity_analysis
-                ${HTTP_SOURCES} )
+	             ${CMAKE_CURRENT_LIST_DIR}/../source/core_http_client.c )
 
     # Build HTTP library target without custom config dependency.
     target_compile_definitions( coverity_analysis PUBLIC HTTP_DO_NOT_USE_CUSTOM_CONFIG=1 )
@@ -52,8 +52,28 @@ if( COV_ANALYSIS )
     # HTTP public include path.
     target_include_directories( coverity_analysis PUBLIC ${HTTP_INCLUDE_PUBLIC_DIRS} )
 
-    # Build HTTP library target without logging
-    target_compile_options(coverity_analysis PUBLIC -DNDEBUG )
+    target_compile_options( coverity_analysis PUBLIC
+        # Build HTTP library target without logging
+        -DNDEBUG
+
+        ### Gnu/Clang C Options
+        $<$<COMPILE_LANG_AND_ID:C,GNU>:-fdiagnostics-color=always>
+        $<$<COMPILE_LANG_AND_ID:C,Clang>:-fcolor-diagnostics>
+
+        $<$<COMPILE_LANG_AND_ID:C,Clang,GNU>:-Wall>
+        $<$<COMPILE_LANG_AND_ID:C,Clang,GNU>:-Wextra>
+        $<$<COMPILE_LANG_AND_ID:C,Clang,GNU>:-Wpedantic>
+        $<$<COMPILE_LANG_AND_ID:C,Clang,GNU>:-Werror>
+        $<$<COMPILE_LANG_AND_ID:C,Clang,GNU>:-Wconversion>
+        $<$<COMPILE_LANG_AND_ID:C,Clang>:-Weverything>
+
+        # Suppressions required to build clean with clang.
+        $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-unused-macros>
+        $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-padded>
+        $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-missing-variable-declarations>
+        $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-covered-switch-default>
+        $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-cast-align>
+    )
 endif()
 # ===================== Clone needed third-party libraries ======================
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -44,7 +44,7 @@ if( COV_ANALYSIS )
 
     # Target for Coverity analysis that builds the library.
     add_library( coverity_analysis
-	             ${CMAKE_CURRENT_LIST_DIR}/../source/core_http_client.c )
+                 ${CMAKE_CURRENT_LIST_DIR}/../source/core_http_client.c )
 
     # Build HTTP library target without custom config dependency.
     target_compile_definitions( coverity_analysis PUBLIC HTTP_DO_NOT_USE_CUSTOM_CONFIG=1 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -60,9 +60,8 @@ if( COV_ANALYSIS )
         -Wall
         -Wextra
         -Wpedantic
-        -Werror
         -Wconversion
-        -Weverything
+        -Werror
     )
 endif()
 # ===================== Clone needed third-party libraries ======================


### PR DESCRIPTION
Add compiler warning check in the CI workflow

Description
-----------
* Fix conversion compiler warning
* Update coverity_analysis target to build core_http_client.c only
* Adding the compile warning check in coverity_analysis target

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] ~~I have modified and/or added unit-tests to cover the code changes in this Pull Request.~~

Related Issue
-----------
<!-- If any, please provide issue ID. -->
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
