### PR TITLE
Fix comment in config defaults header file

### DIFF
--- a/source/include/core_http_config_defaults.h
+++ b/source/include/core_http_config_defaults.h
@@ -59,18 +59,18 @@
 
 /**
  * @brief The maximum duration between non-empty network reads while receiving
- * an HTTP response via the #HTTPClient_Send API function.
+ * an HTTP response via the #HTTPClient_ReceiveAndParseHttpResponse API function.
  *
  * The transport receive function may be called multiple times until the end of
  * the response is detected by the parser. This timeout represents the maximum
  * duration that is allowed without any data reception from the network for the
  * incoming response.
  *
- * If the timeout expires, the #HTTPClient_Send function will return
+ * If the timeout expires, the #HTTPClient_ReceiveAndParseHttpResponse function will return
  * #HTTPNetworkError.
  *
  * If #HTTPResponse_t.getTime is set to NULL, then this HTTP_RECV_RETRY_TIMEOUT_MS
- * is unused. When this timeout is unused, #HTTPClient_Send will not retry the
+ * is unused. When this timeout is unused, #HTTPClient_ReceiveAndParseHttpResponse will not retry the
  * transport receive calls that return zero bytes read.
  *
  * <b>Possible values:</b> Any positive 32 bit integer. A small timeout value


### PR DESCRIPTION
Clean up comment in core_http_config_defaults.h

Description
-----------
The comment for the `HTTP_RECV_RETRY_TIMEOUT_MS` config item references `HTTPClient_Send` when I think it actually applies to `HTTPClient_ReceiveAndParseHttpResponse` (based on the name and because that is where this value is used in the source). Updated the comment but feel free to close if I'm mistaken.


Test Steps
-----------


Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
Have a linker error that I need to debug  when trying to build the tests so haven't run those, comment change only though

- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
