### PR TITLE
Add write permissions to doxygen generation workflow on main

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -1,4 +1,9 @@
 name: Doxygen Generation
+
+# Needs this to write to gh-pages branch.
+permissions:
+  contents: write
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Add `contents: write` permission to the doxygen generation workflow to allow it to push generated documentation to the gh-pages branch.

This fixes the doxygen deployment issue where the workflow lacks permission to write to the repository.