### PR TITLE
coreHTTP: remove redundant lower-bound assert for parsing state

### DIFF
--- a/source/core_http_client.c
+++ b/source/core_http_client.c
@@ -1994,8 +1994,7 @@ static HTTPStatus_t getFinalResponseStatus( HTTPParsingState_t parsingState,
 {
     HTTPStatus_t returnStatus = HTTPSuccess;
 
-    assert( parsingState >= HTTP_PARSING_NONE &&
-            parsingState <= HTTP_PARSING_COMPLETE );
+    assert( parsingState <= HTTP_PARSING_COMPLETE );
     assert( totalReceived <= pResponse->bufferLen );
 
     /* If no parsing occurred, that means network data was never received. */


### PR DESCRIPTION
Description
-----------
This PR removes a redundant lower-bound assertion in getFinalResponseStatus():

```
assert( parsingState >= HTTP_PARSING_NONE &&
        parsingState <= HTTP_PARSING_COMPLETE );
```
HTTP_PARSING_NONE is 0. Some compilers (observed with IAR EWARM) perform enum range analysis and flag parsingState >= 0 as an always-true / pointless comparison, which breaks builds when warnings are treated as errors.

The upper-bound assert is preserved:
```
assert( parsingState <= HTTP_PARSING_COMPLETE );
```

No functional behavior change is intended; this is a build/diagnostic robustness improvement.

Test Steps
-----------
Build any project that compiles source/core_http_client.c using IAR EWARM with warnings treated as errors (Werror).
Before this change, IAR reports a “pointless comparison / always true” diagnostic on the lower-bound check (>= HTTP_PARSING_NONE).
After this change, source/core_http_client.c compiles cleanly.

Environment
-----------
Toolchain: IAR EWARM (e.g. 9.70.x)
Build mode: warnings-as-errors enabled

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [ ]  I have modified and/or added unit-tests to cover the code changes in this Pull Request. (Not applicable; assert-only diagnostic fix.)

Related Issue
-----------
N/A (build diagnostic issue observed with IAR when warnings are treated as errors).
