### PR TITLE
Fix INT32_MIN range formatting

### DIFF
--- a/source/core_http_client.c
+++ b/source/core_http_client.c
@@ -1246,12 +1246,8 @@ static uint8_t convertInt32ToAscii( int32_t value,
                                     size_t bufferLength )
 {
     /* As input value may be altered and MISRA C 2012 rule 17.8 prevents
-     * modification of parameter, a local copy of the parameter is stored.
-     * absoluteValue stores the positive version of the input value. Its type
-     * remains the same type as the input value to avoid unnecessary casting on
-     * a privately used variable. This variable's size will always be less
-     * than INT32_MAX. */
-    int32_t absoluteValue = value;
+     * modification of parameter, a local copy of the parameter is stored. */
+    uint32_t absoluteValue;
     uint8_t numOfDigits = 0U;
     uint8_t index = 0U;
     uint8_t isNegative = 0U;
@@ -1265,21 +1261,32 @@ static uint8_t convertInt32ToAscii( int32_t value,
     /* If the value is negative, write the '-' (minus) character to the buffer. */
     if( value < 0 )
     {
+        /* INT32_MIN cannot be negated as a signed int32_t (overflow / UB).
+         * Handle it as an unsigned magnitude instead. */
         isNegative = 1U;
-
         *pBuffer = '-';
 
-        /* Convert the value to its absolute representation. */
-        absoluteValue = value * ( -1 );
+        if( value == INT32_MIN )
+        {
+            absoluteValue = ( ( uint32_t ) INT32_MAX ) + 1U;
+        }
+        else
+        {
+            absoluteValue = ( uint32_t ) ( -value );
+        }
+    }
+    else
+    {
+        absoluteValue = ( uint32_t ) value;
     }
 
     /* Write the absolute integer value in reverse ASCII representation. */
     do
     {
-        pBuffer[ isNegative + numOfDigits ] = ( char ) ( ( absoluteValue % 10 ) + '0' );
+        pBuffer[ isNegative + numOfDigits ] = ( char ) ( ( absoluteValue % 10U ) + '0' );
         numOfDigits++;
-        absoluteValue /= 10;
-    } while( absoluteValue != 0 );
+        absoluteValue /= 10U;
+    } while( absoluteValue != 0U );
 
     /* Reverse the digits in the buffer to store the correct ASCII representation
      * of the value. */

--- a/test/cbmc/proofs/convertInt32ToAscii/Makefile
+++ b/test/cbmc/proofs/convertInt32ToAscii/Makefile
@@ -1,0 +1,12 @@
+HARNESS_ENTRY=convertInt32ToAscii_harness
+HARNESS_FILE=$(HARNESS_ENTRY)
+PROOF_UID=convertInt32ToAscii
+
+UNWINDSET += __CPROVER_file_local_core_http_client_c_convertInt32ToAscii.0:11
+UNWINDSET += __CPROVER_file_local_core_http_client_c_convertInt32ToAscii.1:11
+
+PROJECT_SOURCES += $(SRCDIR)/source/core_http_client.c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+
+include ../Makefile.common

--- a/test/cbmc/proofs/convertInt32ToAscii/README.md
+++ b/test/cbmc/proofs/convertInt32ToAscii/README.md
@@ -1,0 +1,4 @@
+convertInt32ToAscii proof
+=========================
+
+This proof checks that `convertInt32ToAscii` safely serializes `INT32_MIN`.

--- a/test/cbmc/proofs/convertInt32ToAscii/convertInt32ToAscii_harness.c
+++ b/test/cbmc/proofs/convertInt32ToAscii/convertInt32ToAscii_harness.c
@@ -1,0 +1,29 @@
+/*
+ * coreHTTP
+ * Copyright (C) 2024 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+uint8_t __CPROVER_file_local_core_http_client_c_convertInt32ToAscii( int32_t value,
+                                                                    char * pBuffer,
+                                                                    size_t bufferLength );
+
+void convertInt32ToAscii_harness( void )
+{
+    static const char expected[] = "-2147483648";
+    char buffer[ sizeof( expected ) ] = { 0 };
+    uint8_t bytesWritten;
+
+    bytesWritten = __CPROVER_file_local_core_http_client_c_convertInt32ToAscii( INT32_MIN,
+                                                                                 buffer,
+                                                                                 sizeof( buffer ) );
+
+    assert( bytesWritten == ( sizeof( expected ) - 1U ) );
+    assert( memcmp( buffer, expected, bytesWritten ) == 0 );
+}


### PR DESCRIPTION
## Summary

`convertInt32ToAscii()` negated negative `int32_t` values before formatting them. The minimum signed 32-bit value cannot be represented by that negation, so the helper produced incorrect digits for `INT32_MIN`.

Use an unsigned magnitude for the conversion, including the exact `INT32_MIN` magnitude, while keeping the existing length-based buffer contract. Add a focused CBMC harness for the boundary value.

## Test Steps

- Reproduced the incorrect baseline output and the corrected `-2147483648` output with a host harness using the real conversion logic.
- Configured and built the project with Linux GCC:
  `cmake -S test -B build-linux-codex -G Ninja -DBUILD_CLONE_SUBMODULES=ON -DUNITTEST=1`
- Ran `ctest --test-dir build-linux-codex -E system --output-on-failure`.
- Result: `100% tests passed, 0 tests failed out of 2`.
- The new CBMC proof is included; CBMC execution was not available in the local environment.

## Checklist

- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

